### PR TITLE
make remapping of `>` in insert mode local to buffer

### DIFF
--- a/after/ftplugin/puppet.vim
+++ b/after/ftplugin/puppet.vim
@@ -1,4 +1,4 @@
-inoremap <silent> > ><Esc>:call <SID>puppetalign()<CR>A
+inoremap <buffer> <silent> > ><Esc>:call <SID>puppetalign()<CR>A
 function! s:puppetalign()
     let p = '^\s*\w+\s*=>.*$'
     let lineContainsHashrocket = getline('.') =~# '^\s*\w+\s*=>'


### PR DESCRIPTION
Otherwise this mapping affects all buffers loaded after the puppet one,
regardless of type.
