### PR TITLE
Puppet multiline comments

### DIFF
--- a/syntax/puppet.vim
+++ b/syntax/puppet.vim
@@ -33,7 +33,7 @@ syn match   puppetTypeDefault    "[A-Z]\w*" contained
 syn match   puppetParam           "\w\+\s*\(=\|+\)>" contains=puppetTypeRArrow,puppetParamName
 syn match   puppetParamRArrow       "\(=\|+\)>" contained
 syn match   puppetParamName       "\w\+" contained
-syn match   puppetVariable           "$\(\w\+\(::\w\+\)*\|{\w\+\(::\w\+\)*}\)"
+syn match   puppetVariable           "$\(\(\(::\)\?\w\+\)\+\|{\(\(::\)\?\w\+\)\+}\)"
 syn match   puppetParen           "("
 syn match   puppetParen           ")"
 syn match   puppetBrace           "{"


### PR DESCRIPTION
Added in a syntax region to handle the Puppet (C style) multi-line comments.
Added in plusignment operator.
