### PR TITLE
Adds highlighting for 'require' statement.

### DIFF
--- a/syntax/puppet.vim
+++ b/syntax/puppet.vim
@@ -16,6 +16,10 @@ elseif exists("b:current_syntax")
   finish
 endif
 
+" require statement
+syn match puppetKeyword "require\s"
+syn match puppetString "[^require\s].*$"
+
 syn region  puppetDefine        start="^\s*\(class\|define\|site\|node\)\s+" end="{" contains=puppetDefType,puppetDefName,puppetDefArguments
 syn match   puppetDefType       "\(class\|define\|site\|node\|inherits\)" contained
 syn match   puppetInherits      "inherits" contained


### PR DESCRIPTION
Currently, the `require` statement in [rodjek/vim-puppet](http://github.com/rodjek/vim-puppet) does not have any syntax highlighting.

![](http://i.imgur.com/nfAjt.png)

But, with this pull request (using [Solarized](http://ethanschoonover.com/solarized)):

![](http://i.imgur.com/xfsYj.png)

And for reference, this is what syntax highlighting for Puppet `require` looks like on GitHub:

![](http://i.imgur.com/Avplx.png)
