### PR TITLE
Only closing braces/brackets/parens were being hilighted.

### DIFF
--- a/syntax/puppet.vim
+++ b/syntax/puppet.vim
@@ -31,9 +31,9 @@ syn match   puppetNodeRe        "/.*/" contained
 " match 'foo::bar' in 'class foo::bar { ...'
 " match 'Foo::Bar' in 'Foo::Bar["..."]
 "FIXME: "Foo-bar" doesn't get highlighted as expected, although "foo-bar" does.
-syn match   puppetInstance      "[A-Za-z0-9_-]\+\(::[A-Za-z0-9_-]\+\)*\s*{" contains=puppetTypeName,puppetTypeDefault,@NoSpell
-syn match   puppetInstance      "[A-Z][a-z_-]\+\(::[A-Z][a-z_-]\+\)*\s*[[{]" contains=puppetTypeName,puppetTypeDefault,@NoSpell
-syn match   puppetInstance      "[A-Z][a-z_-]\+\(::[A-Z][a-z_-]\+\)*\s*<\?<|" contains=puppetTypeName,puppetTypeDefault,@NoSpell
+syn match   puppetInstance      "[A-Za-z0-9_-]\+\(::[A-Za-z0-9_-]\+\)*\s*" contains=puppetTypeName,puppetTypeDefault,@NoSpell
+syn match   puppetInstance      "[A-Z][a-z_-]\+\(::[A-Z][a-z_-]\+\)*\s*[{]" contains=puppetTypeName,puppetTypeDefault,@NoSpell
+syn match   puppetInstance      "[A-Z][a-z_-]\+\(::[A-Z][a-z_-]\+\)*\s*" contains=puppetTypeName,puppetTypeDefault,@NoSpell
 syn match   puppetTypeName      "[a-z]\w*" contained
 syn match   puppetTypeDefault   "[A-Z]\w*" contained
 
@@ -59,8 +59,6 @@ syn keyword puppetParamKeyword  present absent purged latest installed running s
 syn keyword puppetParamSpecial  true false undef contained
 syn match   puppetParamDigits   "[0-9]\+"
 
-" match 'template' in 'content => template("...")'
-syn match   puppetParam         "\w\+\s*[=+]>\s*\w\+\s*(" contains=puppetFunction,puppetParamName
 " statements
 syn region  puppetFunction      start="^\s*\(alert\|crit\|debug\|emerg\|err\|fail\|include\|info\|notice\|realize\|require\|search\|tag\|warning\)\s*(" end=")" contained contains=puppetString
 " rvalues


### PR DESCRIPTION
Not totally sure that this was the right way to fix it, but I've edited some of the regexes, and it's fixed a problem for me where only the closing braces, brackets, '<<||>>' characters, and parenthesis were being hilighted. Doesn't appear to have broken anything else.

However, with this commit, we lose hilighting on the word 'template' in `source => template()` stanzas, but that regex seemed to be causing problems elsewhere (hilighting parameters in parameterized classes, class names, etc)/ I think having correct hilighting on those is more important that the 'template' function.

If there's anything I can do to improve this or make it nicer, let me know!
