### PR TITLE
Use backslash to escape keywordprg whitespace

### DIFF
--- a/ftplugin/puppet.vim
+++ b/ftplugin/puppet.vim
@@ -2,5 +2,5 @@ setl ts=2
 setl sts=2
 setl sw=2
 setl et
-setl keywordprg="puppet describe --providers"
+setl keywordprg=puppet\ describe\ --providers
 setl iskeyword=-,:,@,48-57,_,192-255


### PR DESCRIPTION
According to `:help option-backslash` "the double quote character starts a comment". So in order to include spaces in the keywordprg command they have to be escaped with a backslash.
