### PR TITLE
highlight TODO: FIXME: etc...

### DIFF
--- a/syntax/puppet.vim
+++ b/syntax/puppet.vim
@@ -87,6 +87,7 @@ syn match   puppetClass         "[A-Za-z0-9_-]\+\(::[A-Za-z0-9_-]\+\)\+" contain
 syn match   puppetComment            "\s*#.*$" contains=puppetTodo,@Spell
 syn region  puppetMultilineComment  start="/\*" end="\*/" contains=puppetTodo,@Spell
 syn keyword puppetTodo               TODO NOTE FIXME XXX BUG HACK contained
+syn keyword puppetTodo               TODO: NOTE: FIXME: XXX: BUG: HACK: contained
 
 " Define the default highlighting.
 " For version 5.7 and earlier: only when not done already


### PR DESCRIPTION
iskeyword contains ':', so it needs to be added explicitly
