### PR TITLE
Add puppet:/// support for gf

### DIFF
--- a/after/ftplugin/puppet.vim
+++ b/after/ftplugin/puppet.vim
@@ -10,7 +10,7 @@ function! s:puppetalign()
     endif
 endfunction
 
-function! s:puppet_gf()
+function! s:puppet_gf(cmd)
   let ret = []
   let line = getline('.')
   let puppet_root = ""
@@ -33,24 +33,26 @@ function! s:puppet_gf()
     endif
   endwhile
 
-  " The normal return value of gf. Return it in case no puppet root was found.
-  " This is not perfect, but something.
-  if puppet_root == ''
-    return expand('<cWORD>')
-  endif
-
   " Insert the puppet root and the path to the selected module's
   " files/ or templates/
-  if url != ""
-    let spl = split(url, '/')
-    let ret = [puppet_root] + spl[:1] + ['files'] + spl[2:]
-  elseif template != ""
-    let spl = split(template, '/')
-    let ret = [puppet_root, 'modules', spl[0], 'templates'] + spl[1:]
+  if puppet_root != ''
+    if url != ""
+      let spl = split(url, '/')
+      let ret = [puppet_root] + spl[:1] + ['files'] + spl[2:]
+    elseif template != ""
+      let spl = split(template, '/')
+      let ret = [puppet_root, 'modules', spl[0], 'templates'] + spl[1:]
+    endif
   endif
 
-  return join(ret, '/')
+  " No puppet root or match. Fallback to default behaviour!
+  if puppet_root == '' || empty(ret)
+    normal! gf
+    return
+  endif
+
+  exe a:cmd join(ret, "/")
 endfunction
 
-nmap <buffer> <silent> gf :edit `=<SID>puppet_gf()`<cr>
-nmap <buffer> <silent> <c-w>f :split `=<SID>puppet_gf()`<cr>
+nmap <buffer> <silent> gf :call <SID>puppet_gf('edit')<cr>
+nmap <buffer> <silent> <c-w>f :call <SID>puppet_gf('split')<cr>

--- a/after/ftplugin/puppet.vim
+++ b/after/ftplugin/puppet.vim
@@ -9,3 +9,40 @@ function! s:puppetalign()
         normal! 0
     endif
 endfunction
+
+function! s:puppet_gf()
+  let puppet_root = ""
+  let word = matchstr(getline('.'), "'".'puppet:///\zsmodules.*\ze'."'")
+  let fn = fnamemodify(expand('%'), ":p")
+  let old_fn = ""
+
+  " Find the puppet root, if any
+  while fn != old_fn
+    let old_fn = fn
+    let fn = fnamemodify(fn, ":h")
+
+    " If there is a hiera-data directory, we can assume that this is the root.
+    " TODO: Maybe optionally use a global variable for where the root is?
+    if isdirectory(fn . '/hiera-data')
+      let puppet_root = fn
+      break
+    endif
+  endwhile
+
+  if puppet_root != "" && word != ""
+    " Insert the puppet root and the 'files' directory
+    let spl = split(word, '/')
+    let spl = insert(spl, puppet_root)
+    let spl = insert(spl, 'files', 3)
+
+    " Join it back and return it
+    return join(spl, '/')
+  endif
+
+  " The normal return value of gf. Return it in case something goes wrong.
+  " This is not perfect, but something.
+  return expand('<cWORD>')
+endfunction
+
+nmap <buffer> <silent> gf :edit `=<SID>puppet_gf()`<cr>
+nmap <buffer> <silent> <c-w>f :split `=<SID>puppet_gf()`<cr>


### PR DESCRIPTION
Override vims default gf behaviour to make it try files for the puppet:/// URLs
that can be used in manifests. Includes a fallback to the normal gf behaviour.

This might not be ready to merge without some discussion. I'm not certain if this is useful for all puppet projects, but it works in the non-modularised project I am currently working on. I'm also not sure if looking for `hiera-data` is the best way of finding the puppet project root.

Is this something that could be useful in the vim-puppet plugin? If so, I might be able to add support for following `template()` paths as well.
