### PR TITLE
puppet filetype not properly set if there are comments at the top of the file

### DIFF
--- a/ftdetect/puppet.vim
+++ b/ftdetect/puppet.vim
@@ -1,1 +1,4 @@
-au! BufRead,BufNewFile *.pp setfiletype puppet
+augroup puppet_ftdetect
+  au!
+  au BufRead,BufNewFile *.pp setfiletype puppet
+augroup END


### PR DESCRIPTION
In the bottom of `/usr/share/vim/vim74/filetype.vim` there is a fallback feature that sets `ft=conf` if no other filetype is set and if one of the first five lines in the file starts with a comment. This fallback is precisely below `runtime! ftdetect/*`, so the vim-puppet ftdetect should have been run already.

I'm not sure why, but I always get `ft=conf` if there are comments at the top of the file, but `ft=puppet` otherwise.

Anyway, the whole thing can be avoided by `let g:ft_ignore_pat = '*.pp$'`, which will disable the fallback for puppet files. I have no idea why `did_filetype()` would return false.

I'm running vim 7.4.86 and the latest version of vim-puppet.
