### PR TITLE
Don't indent on ordering arrow

### DIFF
--- a/indent/puppet.vim
+++ b/indent/puppet.vim
@@ -76,6 +76,19 @@ function! GetPuppetIndent()
     if line =~ '^\s*}\s*els\(e\|if\).*{\s*$'
         let ind -= &sw
     endif
+    
+    " Don't indent resources that are one after another with a ->(ordering arrow)
+    " file {'somefile':
+    "    ...
+    " } ->
+    "
+    " package { 'mycoolpackage':
+    "    ...
+    " }
+    if line =~ '->$'
+        let ind -= &sw
+    endif
+
 
     return ind
 endfunction


### PR DESCRIPTION
The current indention will indent the second resource when ordering arrow is used.

``` puppet
file {'somefile':
    ...
} ->

package { 'mycoolpackage':
    ...
}
```

should be left as is
