### PR TITLE
Include Puppetfile in ftdetect

### DIFF
--- a/ftdetect/puppet.vim
+++ b/ftdetect/puppet.vim
@@ -1,1 +1,2 @@
 au! BufRead,BufNewFile *.pp setfiletype puppet
++au! BufRead,BufNewFile Puppetfile setfiletype ruby


### PR DESCRIPTION
Allows Puppetfile to be auto-detected by vim as ft=ruby
