### PR TITLE
Remove range in ftdetect

### DIFF
--- a/ftdetect/puppet.vim
+++ b/ftdetect/puppet.vim
@@ -1,2 +1,2 @@
 au! BufRead,BufNewFile *.pp setfiletype puppet
-+au! BufRead,BufNewFile Puppetfile setfiletype ruby
+au! BufRead,BufNewFile Puppetfile setfiletype ruby


### PR DESCRIPTION
Looks like a possibly bad copy-paste:

```
$ vim  /Users/jsmith/Documents/joe-dotfiles/vim/bundle/vim-puppet/ftdetect/puppet.vim
Error detected while processing /Users/jsmith/Documents/joe-dotfiles/vim/bundle/vim-puppet/ftdetect/puppet.vim:
line    2:
E481: No range allowed: +au! BufRead,BufNewFile Puppetfile setfiletype ruby
Press ENTER or type command to continue
```
