### PR TITLE
Rename contains keyword to contain

### DIFF
--- a/syntax/puppet.vim
+++ b/syntax/puppet.vim
@@ -76,7 +76,7 @@ syn region  puppetString        start=+"+ skip=+\\\\\|\\"+ end=+"+ contains=pupp
 syn match   puppetNotVariable   "\\$\w\+" contained
 syn match   puppetNotVariable   "\\${\w\+}" contained
 
-syn keyword puppetKeyword       import inherits include require contains
+syn keyword puppetKeyword       import inherits include require contain
 syn keyword puppetControl       case default if else elsif
 syn keyword puppetSpecial       true false undef
 


### PR DESCRIPTION
There may have been some confusion due to vim's `contains`. :)

https://docs.puppetlabs.com/references/latest/function.html#contain
