### PR TITLE
fix indentation after hash-commented lines

### DIFF
--- a/indent/puppet.vim
+++ b/indent/puppet.vim
@@ -51,10 +51,6 @@ function! GetPuppetIndent()
     let pline = getline(pnum)
     let ind = indent(pnum)
 
-    if pline =~ '^\s*#'
-        return ind
-    endif
-
     if pline =~ '\({\|\[\|(\|:\)$'
         let ind += &sw
     elseif pline =~ ';$' && pline !~ '[^:]\+:.*[=+]>.*'


### PR DESCRIPTION
- auto-indentation badly fails after hash-commented lines. 
- just remving the if-Block resolves that
