### PR TITLE
Allow comments on the end of line

### DIFF
--- a/indent/puppet.vim
+++ b/indent/puppet.vim
@@ -55,7 +55,7 @@ function! GetPuppetIndent()
         return ind
     endif
 
-    if pline =~ '\({\|\[\|(\|:\)$'
+    if pline =~ '\({\|\[\|(\|:\)\s*\(#.*\)\?$'
         let ind += &sw
     elseif pline =~ ';$' && pline !~ '[^:]\+:.*[=+]>.*'
         let ind -= &sw


### PR DESCRIPTION
Comments on the end of line should not change the indent behavior.

Example:

package {
  'apache2': # the main pkg
    ensure => present;
  'apache2-utils': # some more binaries
    ensure => present;
}
