### PR TITLE
Set commentstring to use #.

### DIFF
--- a/ftplugin/puppet.vim
+++ b/ftplugin/puppet.vim
@@ -4,3 +4,4 @@ setl sw=2
 setl et
 setl keywordprg=puppet\ describe\ --providers
 setl iskeyword=-,:,@,48-57,_,192-255
+setl cms=#\ %s


### PR DESCRIPTION
This allows use of e.g. [tpope/vim-commentary](https://github.com/tpope/vim-commentary) to comment and uncomment lines.
