### PR TITLE
Add Syntax Highlighting to Unless Keyword

### DIFF
--- a/syntax/puppet.vim
+++ b/syntax/puppet.vim
@@ -77,7 +77,7 @@ syn match   puppetNotVariable   "\\$\w\+" contained
 syn match   puppetNotVariable   "\\${\w\+}" contained
 
 syn keyword puppetKeyword       import inherits include require contains
-syn keyword puppetControl       case default if else elsif
+syn keyword puppetControl       case default if else elsif unless
 syn keyword puppetSpecial       true false undef
 
 syn match   puppetClass         "[A-Za-z0-9_-]\+\(::[A-Za-z0-9_-]\+\)\+" contains=@NoSpell


### PR DESCRIPTION
The unless keyword should be highlighted in the context of a conditional statement.