### PR TITLE
Add support for highlighting the on_failure keyword.

### DIFF
--- a/syntax/puppet.vim
+++ b/syntax/puppet.vim
@@ -55,7 +55,7 @@ syn match   puppetBrack           "|>"
 " don't match 'bar' in 'foo => bar'
 syn match   puppetParam         "\w\+\s*[=+]>\s*[a-z0-9]\+" contains=puppetParamString,puppetParamName
 syn match   puppetParamString   "[=+]>\s*\w\+" contains=puppetParamKeyword,puppetParamSpecial,puppetParamDigits contained
-syn keyword puppetParamKeyword  present absent purged latest installed running stopped mounted unmounted role configured file directory link contained
+syn keyword puppetParamKeyword  present absent purged latest installed running stopped mounted unmounted role configured file directory link on_failure contained
 syn keyword puppetParamSpecial  true false undef contained
 syn match   puppetParamDigits   "[0-9]\+"
 


### PR DESCRIPTION
In an exec resource:

  logoutput => on_failure,

The "on_failure" value is a keyword supported by Puppet. It should be highlighted just like the "installed" keyword in this package resource:

  enable => installed,

This change adds that.
