### PR TITLE
Prevent puppetVariable highlight freezing VIM

### DIFF
--- a/ftplugin/puppet.vim
+++ b/ftplugin/puppet.vim
@@ -4,3 +4,4 @@ setl sw=2
 setl et
 setl keywordprg=puppet\ describe\ --providers
 setl iskeyword=-,:,@,48-57,_,192-255
+setl cms=#\ %s

--- a/indent/puppet.vim
+++ b/indent/puppet.vim
@@ -51,11 +51,7 @@ function! GetPuppetIndent()
     let pline = getline(pnum)
     let ind = indent(pnum)
 
-    if pline =~ '^\s*#'
-        return ind
-    endif
-
-    if pline =~ '\({\|\[\|(\|:\)$'
+    if pline =~ '\({\|\[\|(\|:\)\s*\(#.*\)\?$'
         let ind += &sw
     elseif pline =~ ';$' && pline !~ '[^:]\+:.*[=+]>.*'
         let ind -= &sw

--- a/syntax/puppet.vim
+++ b/syntax/puppet.vim
@@ -40,7 +40,7 @@ syn match   puppetTypeDefault   "[A-Z]\w*" contained
 syn match   puppetParam           "\w\+\s*\(=\|+\)>" contains=puppetTypeRArrow,puppetParamName
 syn match   puppetParamRArrow       "\(=\|+\)>" contained
 syn match   puppetParamName       "\w\+" contained contains=@NoSpell
-syn match   puppetVariable           "$\(\(\(::\)\?\w\+\)\+\|{\(\(::\)\?\w\+\)\+}\)"
+syn match   puppetVariable        "$\(\(::\)\?\w\+\|{\(::\)\?\w\+}\)" 
 syn match   puppetParen           "("
 syn match   puppetParen           ")"
 syn match   puppetBrace           "{"

--- a/syntax/puppet.vim
+++ b/syntax/puppet.vim
@@ -19,13 +19,14 @@ endif
 " match class/definition/node declarations
 syn region  puppetDefine        start="^\s*\(class\|define\|node\)\s" end="{" contains=puppetDefType,puppetDefName,puppetDefArguments,puppetNodeRe,@NoSpell
 syn keyword puppetDefType       class define node inherits contained
-syn region  puppetDefArguments  start="(" end=")" contained contains=puppetArgument,puppetString,puppetComment,puppetMultilineComment
+syn region  puppetDefArguments  start="(" end=")" contained contains=puppetArgument,puppetString,puppetComment,puppetMultilineComment,puppetDataTypes
 syn match   puppetArgument      "\w\+" contained
 syn match   puppetArgument      "\$\w\+" contained
 syn match   puppetArgument      "'[^']+'" contained
 syn match   puppetArgument      '"[^"]+"' contained
 syn match   puppetDefName       "\w\+" contained
 syn match   puppetNodeRe        "/.*/" contained
+syn keyword puppetDataTypes     String Integer Float Numeric Boolean Array Hash Regexp Undef Default Resource Class Scalar Collection Variant Data Pattern Enum Tuple Struct Optional Catalogentry Type Any Callable
 
 " match 'foo' in 'class foo { ...'
 " match 'foo::bar' in 'class foo::bar { ...'
@@ -55,7 +56,7 @@ syn match   puppetBrack           "|>"
 " don't match 'bar' in 'foo => bar'
 syn match   puppetParam         "\w\+\s*[=+]>\s*[a-z0-9]\+" contains=puppetParamString,puppetParamName
 syn match   puppetParamString   "[=+]>\s*\w\+" contains=puppetParamKeyword,puppetParamSpecial,puppetParamDigits contained
-syn keyword puppetParamKeyword  present absent purged latest installed running stopped mounted unmounted role configured file directory link contained
+syn keyword puppetParamKeyword  present absent purged latest installed running stopped mounted unmounted role configured file directory link on_failure contained
 syn keyword puppetParamSpecial  true false undef contained
 syn match   puppetParamDigits   "[0-9]\+"
 
@@ -76,7 +77,7 @@ syn region  puppetString        start=+"+ skip=+\\\\\|\\"+ end=+"+ contains=pupp
 syn match   puppetNotVariable   "\\$\w\+" contained
 syn match   puppetNotVariable   "\\${\w\+}" contained
 
-syn keyword puppetKeyword       import inherits include require contains
+syn keyword puppetKeyword       import inherits include require contain
 syn keyword puppetControl       case default if else elsif unless
 syn keyword puppetSpecial       true false undef
 

--- a/syntax/puppet.vim
+++ b/syntax/puppet.vim
@@ -67,8 +67,8 @@ syn region  puppetFunction      start="^\s*\(alert\|crit\|debug\|emerg\|err\|fai
 " rvalues
 syn region  puppetFunction      start="^\s*\(defined\|file\|fqdn_rand\|generate\|inline_template\|regsubst\|sha1\|shellquote\|split\|sprintf\|tagged\|template\|versioncmp\)\s*(" end=")" contained contains=puppetString
 
-syn match   puppetVariable      "$[a-zA-Z0-9_:]\+" contains=@NoSpell
-syn match   puppetVariable      "${[a-zA-Z0-9_:]\+}" contains=@NoSpell
+syn match   puppetVariable      "$[a-zA-Z0-9_:\[\]]\+" contains=@NoSpell
+syn match   puppetVariable      "${[a-zA-Z0-9_:\[\]]\+}" contains=@NoSpell
 
 " match anything between simple/double quotes.
 " don't match variables if preceded by a backslash.

--- a/syntax/puppet.vim
+++ b/syntax/puppet.vim
@@ -77,7 +77,7 @@ syn match   puppetNotVariable   "\\$\w\+" contained
 syn match   puppetNotVariable   "\\${\w\+}" contained
 
 syn keyword puppetKeyword       import inherits include require contains
-syn keyword puppetControl       case default if else elsif
+syn keyword puppetControl       case default if else elsif unless
 syn keyword puppetSpecial       true false undef
 
 syn match   puppetClass         "[A-Za-z0-9_-]\+\(::[A-Za-z0-9_-]\+\)\+" contains=@NoSpell


### PR DESCRIPTION
Previous regex attempted to parse too much, when simply highlighting a variable.
Fixes Issue#39 and #32
