### PR TITLE
Rewrite the auto-align code to handle nested structures

### DIFF
--- a/after/ftplugin/puppet.vim
+++ b/after/ftplugin/puppet.vim
@@ -2,15 +2,6 @@ if !exists('g:puppet_align_hashes')
     let g:puppet_align_hashes = 1
 endif
 
-if g:puppet_align_hashes && exists(':Tabularize')
-    inoremap <buffer> <silent> > ><Esc>:call <SID>puppetalign()<CR>a
-    function! s:puppetalign()
-        let p = '^\s*\w+\s*[=+]>.*$'
-        let column = strlen(substitute(getline('.')[0:col('.')],'\([^=]\|=[^>]\)','','g'))
-        let position = strlen(matchstr(getline('.')[0:col('.')],'.*=>\s*\zs.*'))
-        Tabularize /=>/l1
-        normal! 0
-        echo repeat('\([^=]\|=[^>]\)*=>',column).'\s\{-\}'.repeat('.',position)
-        call search(repeat('\([^=]\|=[^>]\)*=>',column).'\s\{-\}'.repeat('.',position),'ce',line('.'))
-    endfunction
+if g:puppet_align_hashes
+    inoremap <buffer> <silent> > ><Esc>:call puppet#align#AlignHashrockets()<CR>$a
 endif

--- a/autoload/puppet/align.vim
+++ b/autoload/puppet/align.vim
@@ -1,0 +1,63 @@
+function! puppet#align#IndentLevel(lnum)
+    return indent(a:lnum) / &shiftwidth
+endfunction
+
+function! puppet#align#LinesInBlock(lnum)
+    let lines = []
+    let indent_level = puppet#align#IndentLevel(a:lnum)
+
+    let marker = a:lnum - 1
+    while marker >= 1
+        let line_text = getline(marker)
+        let line_indent = puppet#align#IndentLevel(marker)
+
+        if line_text =~? '\v\S'
+            if line_indent < indent_level
+                break
+            elseif line_indent == indent_level
+                call add(lines, marker)
+            endif
+        endif
+
+        let marker -= 1
+    endwhile
+
+    let marker = a:lnum
+    while marker <= line('$')
+        let line_text = getline(marker)
+        let line_indent = puppet#align#IndentLevel(marker)
+
+        if line_text =~? '\v\S'
+            if line_indent < indent_level
+                break
+            elseif line_indent == indent_level
+                call add(lines, marker)
+            endif
+        endif
+
+        let marker += 1
+    endwhile
+
+    return lines
+endfunction
+
+function! puppet#align#AlignHashrockets()
+    let lines_in_block = puppet#align#LinesInBlock(line('.'))
+    let max_left_len = 0
+    let indent_str = printf('%' . indent(line('.')) . 's', '')
+
+    for line_num in lines_in_block
+        let data = matchlist(getline(line_num), '^\s*\(.*\S\)\s*=>\s*\(.*\)$')
+        if !empty(data)
+            let max_left_len = max([max_left_len, strlen(data[1])])
+        endif
+    endfor
+
+    for line_num in lines_in_block
+        let data = matchlist(getline(line_num), '^\s*\(.*\S\)\s*=>\s*\(.*\)$')
+        if !empty(data)
+            let new_line = printf('%s%-' . max_left_len . 's => %s', indent_str, data[1], data[2])
+            call setline(line_num, new_line)
+        endif
+    endfor
+endfunction


### PR DESCRIPTION
Rewrite of the `=>` alignment code to handle nested structures properly. When realigning the lines it will only take into account lines on the same indent level as the current line, meaning that nested data structures will no longer be messed up.

Fixes #28 #56 