### PR TITLE
Puppet4 types

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Provides
 --------
 
   * Formatting based on the latest Puppetlabs Style Guide
-  * Syntax highlighting
+  * Syntax highlighting compatible with puppet 4.x
   * Automatic => alignment
     * If you don't like that, add `let g:puppet_align_hashes = 0` to your vimrc.
   * Doesn't require a bloated JRE

--- a/syntax/puppet.vim
+++ b/syntax/puppet.vim
@@ -19,11 +19,12 @@ endif
 " match class/definition/node declarations
 syn region  puppetDefine        start="^\s*\(class\|define\|node\)\s" end="{" contains=puppetDefType,puppetDefName,puppetDefArguments,puppetNodeRe,@NoSpell
 syn keyword puppetDefType       class define node inherits contained
-syn region  puppetDefArguments  start="(" end=")" contained contains=puppetArgument,puppetString,puppetComment,puppetMultilineComment
+syn region  puppetDefArguments  start="(" end=")" contained contains=puppetType,puppetArgument,puppetString,puppetComment,puppetMultilineComment
 syn match   puppetArgument      "\w\+" contained
 syn match   puppetArgument      "\$\w\+" contained
 syn match   puppetArgument      "'[^']+'" contained
 syn match   puppetArgument      '"[^"]+"' contained
+syn keyword puppetType          String Integer Float Numeric Boolean Array Hash Regexpf Undef Default
 syn match   puppetDefName       "\w\+" contained
 syn match   puppetNodeRe        "/.*/" contained
 
@@ -122,7 +123,7 @@ if version >= 508 || !exists("did_puppet_syn_inits")
   endif
 
   HiLink puppetVariable             Identifier
-  HiLink puppetType                 Identifier
+  HiLink puppetType                 Define
   HiLink puppetKeyword              Keyword
   HiLink puppetComment              Comment
   HiLink puppetMultilineComment     Comment

--- a/syntax/puppet.vim
+++ b/syntax/puppet.vim
@@ -123,7 +123,7 @@ if version >= 508 || !exists("did_puppet_syn_inits")
   endif
 
   HiLink puppetVariable             Identifier
-  HiLink puppetType                 Define
+  HiLink puppetType                 Type
   HiLink puppetKeyword              Keyword
   HiLink puppetComment              Comment
   HiLink puppetMultilineComment     Comment


### PR DESCRIPTION
The only syntax element missing from puppet 4 to cover that version are the type keywords.