### PR TITLE
Don't match keywords or control words when used as a parameter.

### DIFF
--- a/syntax/puppet.vim
+++ b/syntax/puppet.vim
@@ -77,8 +77,9 @@ syn region  puppetString        start=+"+ skip=+\\\\\|\\"+ end=+"+ contains=pupp
 syn match   puppetNotVariable   "\\$\w\+" contained
 syn match   puppetNotVariable   "\\${\w\+}" contained
 
-syn keyword puppetKeyword       import inherits include require contain
-syn keyword puppetControl       case default if else elsif
+" match keywords and control words except when used as a parameter
+syn match   puppetKeyword       "\(import\|inherits\|include\|require\|contain\)\(\s*=>\)\@!"
+syn match   puppetControl       "\(case\|default\|if\|else\|elsif\)\(\s*=>\)\@!"
 syn keyword puppetSpecial       true false undef
 
 syn match   puppetClass         "[A-Za-z0-9_-]\+\(::[A-Za-z0-9_-]\+\)\+" contains=@NoSpell


### PR DESCRIPTION
E.g. the keyword 'require' has a different meaning when used as:

require some::class

or when used as:

service { 'foo':
  ensure  => running,
  require => Package['foo'],
}

The highlighting of 'require' should be the same as 'ensure'.