### PR TITLE
Remap '=>' instead of '>' for hash alignment.

### DIFF
--- a/after/ftplugin/puppet.vim
+++ b/after/ftplugin/puppet.vim
@@ -3,5 +3,5 @@ if !exists('g:puppet_align_hashes')
 endif
 
 if g:puppet_align_hashes
-    inoremap <buffer> <silent> > ><Esc>:call puppet#align#AlignHashrockets()<CR>$a
+    inoremap <buffer> <silent> => =><Esc>:call puppet#align#AlignHashrockets()<CR>$a
 endif


### PR DESCRIPTION
This fixes #31 by mapping the alignment code to trigger when a whole hash rocket is typed, not just a `>` character. The timeout for typing the second character of two-character mappings like this is pretty short, but it works for me most of the time.
