### PR TITLE
Add Ctags and Tagbar support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Provides
   * Syntax highlighting compatible with puppet 4.x
   * Automatic => alignment
     * If you don't like that, add `let g:puppet_align_hashes = 0` to your vimrc.
+  * Ctags support
   * Doesn't require a bloated JRE
   * Doesn't take minutes to open
 
@@ -22,6 +23,7 @@ Additional useful plugins
    snippets for multiple languages, including Puppet. Works with both
    [snipmate](https://github.com/garbas/vim-snipmate) and
    [ultisnips](https://github.com/SirVer/ultisnips).
+ * [Tagbar](https://github.com/majutsushi/tagbar) plugin for Ctags support.
 
 Installation
 ------------

--- a/ctags/puppet.ctags
+++ b/ctags/puppet.ctags
@@ -1,0 +1,10 @@
+--langdef=puppet
+--langmap=puppet:.pp
+--regex-puppet=/^[[:space:]]*class[[:space:]]*([a-z][a-zA-Z0-9_:\-]+)/\1/c,class/
+--regex-puppet=/^[[:space:]]*site[[:space:]]*([a-zA-Z0-9_\-]+)/\1/s,site/
+--regex-puppet=/^[[:space:]]*node[[:space:]]*[\'|\"]*([a-zA-Z0-9_\.\-]+)[\'|\"]*/\1/n,node/
+--regex-puppet=/^[[:space:]]*define[[:space:]]*([a-z][a-zA-Z0-9_:\-]+)/\1/d,definition/
+--regex-puppet=/^[[:space:]]*(include|require)[[:space:]]*([a-zA-Z0-9_:]+)/\2/i,include/
+--regex-puppet=/^[[:space:]]*([\$][a-zA-Z0-9_:]+)[[:space:]]*=/\1/v,variable/
+--regex-puppet=/^[[:space:]]*[~|\-]?>?[[:space:]]*([a-z][a-zA-Z0-9_:]+)[[:space:]]*\{ *(.*):/\1[\2]/r,resource/
+--regex-puppet=/([A-Z][a-zA-Z0-9_:]+)[[:space:]]*\{/\1/f,default/

--- a/ftplugin/puppet_tagbar.vim
+++ b/ftplugin/puppet_tagbar.vim
@@ -1,0 +1,21 @@
+" Puppet set up for Tagbar plugin
+" (https://github.com/majutsushi/tagbar).
+
+if !exists(':Tagbar')
+    finish
+endif
+
+let g:tagbar_type_puppet = {
+  \ 'ctagstype': 'puppet',
+  \ 'kinds': [
+    \ 'c:Classes',
+    \ 's:Sites',
+    \ 'n:Nodes',
+    \ 'v:Variables',
+    \ 'i:Includes',
+    \ 'd:Definitions',
+    \ 'r:Resources',
+    \ 'f:Defaults'
+  \],
+    \ 'deffile'   : expand('<sfile>:p:h:h') . '/ctags/puppet.ctags',
+\}


### PR DESCRIPTION
Adds ctags support for use with [Tagbar](https://github.com/majutsushi/tagbar).

![image](https://cloud.githubusercontent.com/assets/69970/26598045/c5f56c2c-4528-11e7-8e1c-088987ef64fe.png)