### PR TITLE
Use non-greedy regex matching when working out the indent.

### DIFF
--- a/autoload/puppet/align.vim
+++ b/autoload/puppet/align.vim
@@ -47,14 +47,14 @@ function! puppet#align#AlignHashrockets()
     let indent_str = printf('%' . indent(line('.')) . 's', '')
 
     for line_num in lines_in_block
-        let data = matchlist(getline(line_num), '^\s*\(.*\S\)\s*=>\s*\(.*\)$')
+        let data = matchlist(getline(line_num), '^\s*\(.\{-}\S\)\s*=>\s*\(.*\)$')
         if !empty(data)
             let max_left_len = max([max_left_len, strlen(data[1])])
         endif
     endfor
 
     for line_num in lines_in_block
-        let data = matchlist(getline(line_num), '^\s*\(.*\S\)\s*=>\s*\(.*\)$')
+        let data = matchlist(getline(line_num), '^\s*\(.\{-}\S\)\s*=>\s*\(.*\)$')
         if !empty(data)
             let new_line = printf('%s%-' . max_left_len . 's => %s', indent_str, data[1], data[2])
             call setline(line_num, new_line)


### PR DESCRIPTION
When using a ternary such as
  'myvar' => $::somevar ? { 1 => 'abc', 2 => 'def', default => 'xyz' }

It would calculate the spaces to the last => and mess up the indent.