### PR TITLE
Add universal ctags support

### DIFF
--- a/ctags/puppet.ctags
+++ b/ctags/puppet.ctags
@@ -4,7 +4,7 @@
 --regex-puppet=/^[[:space:]]*site[[:space:]]*([a-zA-Z0-9_\-]+)/\1/s,site/
 --regex-puppet=/^[[:space:]]*node[[:space:]]*[\'|\"]*([a-zA-Z0-9_\.\-]+)[\'|\"]*/\1/n,node/
 --regex-puppet=/^[[:space:]]*define[[:space:]]*([a-z][a-zA-Z0-9_:\-]+)/\1/d,definition/
---regex-puppet=/^[[:space:]]*(include|require)[[:space:]]*([a-zA-Z0-9_:]+)/\2/i,include/
+--regex-puppet=/^[[:space:]]*(include|require)[[:space:]]*([a-zA-Z0-9_:]+)/\1 \2/i,include/
 --regex-puppet=/^[[:space:]]*([\$][a-zA-Z0-9_:]+)[[:space:]]*=/\1/v,variable/
 --regex-puppet=/^[[:space:]]*[~|\-]?>?[[:space:]]*([a-z][a-zA-Z0-9_:]+)[[:space:]]*\{ *(.*):/\1[\2]/r,resource/
 --regex-puppet=/([A-Z][a-zA-Z0-9_:]+)[[:space:]]*\{/\1/f,default/

--- a/ctags/puppet_u.ctags
+++ b/ctags/puppet_u.ctags
@@ -3,7 +3,7 @@
     --regex-puppet=/^[[:space:]]*node[[:space:]]*[\'|\"]*([a-zA-Z0-9_\.\-]+)[\'|\"]*/\1/n,node/{scope=set}
     --regex-puppet=/^[[:space:]]*class[[:space:]]*([a-z][a-zA-Z0-9_:\-]+)[[:space:]]*\{*/\1/c,class,classes/{scope=set}
     --regex-puppet=/^[[:space:]]*define[[:space:]]*([a-z][a-zA-Z0-9_:\-]+)/\1/d,definition/{scope=set}
-    --regex-puppet=/^[[:space:]]*(include|require)[[:space:]]*([a-zA-Z0-9_:]+)/'\2'/i,include,includes/{scope=ref}
+    --regex-puppet=/^[[:space:]]*(include|require)[[:space:]]*([a-zA-Z0-9_:]+)/\1 \2/i,include,includes/{scope=ref}
     --regex-puppet=/^[[:space:]]*[~|\-]?>?[[:space:]]*([a-z][a-zA-Z0-9_:]+)[[:space:]]*\{[[:space:]]*(.*):/\1[\2]/r,resource/{scope=ref}
     --regex-puppet=/^[[:space:]]*([\$][a-zA-Z0-9_:]+)[[:space:]]*=/\1/v,variable/{scope=ref}
     --regex-puppet=/([A-Z][a-zA-Z0-9_:]+)[[:space:]]*\{/\1/f,default/

--- a/ctags/puppet_u.ctags
+++ b/ctags/puppet_u.ctags
@@ -1,0 +1,10 @@
+--langdef=puppet
+    --map-puppet=+.pp
+    --regex-puppet=/^[[:space:]]*node[[:space:]]*[\'|\"]*([a-zA-Z0-9_\.\-]+)[\'|\"]*/\1/n,node/{scope=set}
+    --regex-puppet=/^[[:space:]]*class[[:space:]]*([a-z][a-zA-Z0-9_:\-]+)[[:space:]]*\{*/\1/c,class,classes/{scope=set}
+    --regex-puppet=/^[[:space:]]*define[[:space:]]*([a-z][a-zA-Z0-9_:\-]+)/\1/d,definition/{scope=set}
+    --regex-puppet=/^[[:space:]]*(include|require)[[:space:]]*([a-zA-Z0-9_:]+)/'\2'/i,include,includes/{scope=ref}
+    --regex-puppet=/^[[:space:]]*[~|\-]?>?[[:space:]]*([a-z][a-zA-Z0-9_:]+)[[:space:]]*\{[[:space:]]*(.*):/\1[\2]/r,resource/{scope=ref}
+    --regex-puppet=/^[[:space:]]*([\$][a-zA-Z0-9_:]+)[[:space:]]*=/\1/v,variable/{scope=ref}
+    --regex-puppet=/([A-Z][a-zA-Z0-9_:]+)[[:space:]]*\{/\1/f,default/
+    --regex-puppet=/^[[:space:]]*site[[:space:]]*([a-zA-Z0-9_\-]+)/\1/s,site/

--- a/ftplugin/puppet_tagbar.vim
+++ b/ftplugin/puppet_tagbar.vim
@@ -5,6 +5,7 @@ if !exists(':Tagbar')
     finish
 endif
 
+let s:ctags_version = system('ctags --version')
 let g:tagbar_type_puppet = {
   \ 'ctagstype': 'puppet',
   \ 'kinds': [
@@ -17,5 +18,26 @@ let g:tagbar_type_puppet = {
     \ 'r:Resources',
     \ 'f:Defaults'
   \],
-    \ 'deffile'   : expand('<sfile>:p:h:h') . '/ctags/puppet.ctags',
 \}
+
+if s:ctags_version =~ 'Universal Ctags'
+    " There no sense to split objects by colon
+    let g:tagbar_type_puppet.sro = '__'
+    let g:tagbar_type_puppet.kind2scope = {
+      \ 'd': 'definition',
+      \ 'c': 'class',
+      \ 'r': 'resource',
+      \ 'i': 'include',
+      \ 'v': 'variable',
+    \}
+    let g:tagbar_type_puppet.scope2kind = {
+      \ 'definition' : 'd',
+      \ 'class'      : 'c',
+      \ 'resource'   : 'r',
+      \ 'include'    : 'i',
+      \ 'variable'   : 'v',
+    \}
+    let g:tagbar_type_puppet.deffile = expand('<sfile>:p:h:h') . '/ctags/puppet_u.ctags'
+elseif s:ctags_version =~ 'Exuberant Ctags'
+    let g:tagbar_type_puppet.deffile = expand('<sfile>:p:h:h') . '/ctags/puppet.ctags'
+endif


### PR DESCRIPTION
Hi. There is  [universal ctags](https://github.com/universal-ctags/ctags/) which supports [hierarchy](https://github.com/universal-ctags/ctags/blob/master/docs/optlib.rst#scope-tracking-in-a-regex-parser).
This PR implements checking, which ctags installed, and chooses config for tagbar accordingly.