### PR TITLE
Indentation errors

### DIFF
--- a/indent/puppet.vim
+++ b/indent/puppet.vim
@@ -30,7 +30,7 @@ function! s:PartOfInclude(lnum)
         if line !~ ',$'
             break
         endif
-        if line =~ '^\s*include\s\+[^,]\+,$'
+        if line =~ '^\s*include\s\+[^,]\+,$' && line !~ '[=>]>'
             return 1
         endif
     endwhile

--- a/indent/puppet.vim
+++ b/indent/puppet.vim
@@ -59,7 +59,11 @@ function! GetPuppetIndent(...)
     let pline = getline(pnum)
     let ind = indent(pnum)
 
-    if pline =~ '^\s*#'
+    " Avoid cases of closing braces or parens on the current line: returning
+    " the same indent here would be premature since for that particular case
+    " we want to instead get the indent level of the matching opening brace or
+    " parenthenses.
+    if pline =~ '^\s*#' && line !~ '^\s*\(}\(,\|;\)\?$\|]:\|],\|}]\|];\?$\|)\)'
         return ind
     endif
 

--- a/indent/puppet.vim
+++ b/indent/puppet.vim
@@ -39,7 +39,8 @@ endfunction
 
 function! s:OpenBrace(lnum)
     call cursor(a:lnum, 1)
-    return searchpair('{\|\[\|(', '', '}\|\]\|)', 'nbW')
+    return searchpair('{\|\[\|(', '', '}\|\]\|)', 'nbW',
+      \ 'synIDattr(synID(line("."), col("."), 0), "name") =~? "comment\\|string"')
 endfunction
 
 ""

--- a/indent/puppet.vim
+++ b/indent/puppet.vim
@@ -67,7 +67,7 @@ function! GetPuppetIndent(...)
         let ind += &sw
     elseif pline =~ ';$' && pline !~ '[^:]\+:.*[=+]>.*'
         let ind -= &sw
-    elseif pline =~ '^\s*include\s\+.*,$'
+    elseif pline =~ '^\s*include\s\+.*,$' && pline !~ '[=+]>'
         let ind += &sw
     endif
 

--- a/indent/puppet.vim
+++ b/indent/puppet.vim
@@ -68,6 +68,12 @@ function! GetPuppetIndent(...)
         return ind
     endif
 
+    " We are inside a multi-line string: if we interfere with indentation here
+    " we're actually changing the contents of of the string!
+    if synIDattr(synID(l:lnum, 1, 0), 'name') =~? 'string'
+        return indent(l:lnum)
+    endif
+
     if pline =~ '\({\|\[\|(\|:\)\s*\(#.*\)\?$'
         let ind += &sw
     elseif pline =~ ';$' && pline !~ '[^:]\+:.*[=+]>.*'

--- a/test/indent/comments_strings.vader
+++ b/test/indent/comments_strings.vader
@@ -1,0 +1,54 @@
+Given puppet (comments before closing brace):
+  node pizzabox.example.com {
+    include some::resource
+    # This comment is very important
+    }
+
+Do (full text indent with '='):
+  gg=G
+
+Expect puppet (closing brace back aligned with start of resource block):
+  node pizzabox.example.com {
+    include some::resource
+    # This comment is very important
+  }
+-------------------------------------------------------------------------------
+Given puppet (closing brace after comment that contains closing brace):
+  class something {
+    #}
+      }
+
+Do (full text indent with '='):
+  gg=G
+
+Expect puppet (closing brace back aligned with start of resource block):
+  class something {
+    #}
+  }
+-------------------------------------------------------------------------------
+" XXX: This test doesn't do what we're expecting: it seems as though indentation
+" doesn't have access to syntax classes during tests.
+Given puppet (multi-line string):
+  class something {
+    $var="
+  This text on new line
+   should not move
+  "
+        this::defined_type { 'foo':
+  content => $var,
+  }
+      }
+
+Do (full text indent with '='):
+  gg=G
+
+Expect puppet (multi-line string does not move and line after resumes indentation):
+  class something {
+    $var="
+  This text on new line
+   should not move
+  "
+    this::defined_type { 'foo':
+      content => $var,
+    }
+  }

--- a/test/indent/comments_strings.vader
+++ b/test/indent/comments_strings.vader
@@ -26,8 +26,6 @@ Expect puppet (closing brace back aligned with start of resource block):
     #}
   }
 -------------------------------------------------------------------------------
-" XXX: This test doesn't do what we're expecting: it seems as though indentation
-" doesn't have access to syntax classes during tests.
 Given puppet (multi-line string):
   class something {
     $var="
@@ -39,7 +37,9 @@ Given puppet (multi-line string):
   }
       }
 
+" XXX Redraw the screen to ensure that syntax highlighting has run
 Do (full text indent with '='):
+  \<C-o>:redraw | normal! gs\<cr>
   gg=G
 
 Expect puppet (multi-line string does not move and line after resumes indentation):

--- a/test/indent/include.vader
+++ b/test/indent/include.vader
@@ -1,0 +1,55 @@
+" We want includes that bring in more than one classes and that span multiple
+" lines to be indented until we have the last resource name without a trailing
+" comma.
+Given puppet (include of multiple classes over multiple lines):
+  include foo::moo,
+  foo::moo::boo,
+        foo::baa
+
+Do (full text indent with '='):
+  gg=G
+
+Expect puppet (indented include):
+  include foo::moo,
+    foo::moo::boo,
+    foo::baa
+-------------------------------------------------------------------------------
+" This indentation of includes must not affect resource parameters that are
+" named include.
+Given puppet (resource with param named include):
+  some::resouce { 'namehere':
+    include => ['s1', 's2'],
+  otherparam => 'value',
+
+Do (full text indent with '='):
+  gg=G
+
+Expect puppet (properly aligned parameters):
+  some::resouce { 'namehere':
+    include => ['s1', 's2'],
+    otherparam => 'value',
+-------------------------------------------------------------------------------
+" This case is similar to the one above but would trigger only when the line
+" just above the current line (the line affected here would be
+" "following::resource ...") was something that didn't end with a trailing
+" comma. This would trigger evaluation of PartOfInclude and would end up
+" finding the parameter named include which would lead to an indentation error
+" for following::resource.
+Given puppet (resource with param named include contained in class):
+  class module::blah {
+    some::resouce { 'namehere':
+      include => ['s1', 's2'],
+      otherparam => 'value',
+    }
+      following::resource { 'identifier':
+
+Do (full text indent with '='):
+  gg=G
+
+Expect puppet (second contained resource should align with the first one):
+  class module::blah {
+    some::resouce { 'namehere':
+      include => ['s1', 's2'],
+      otherparam => 'value',
+    }
+    following::resource { 'identifier':


### PR DESCRIPTION
This patch series should fix the bug reports that are currently reported plus a couple other indentation bugs that I've discovered right after fixing the second bug:

 * #99 : superfluous indentation for a resource param named "include"
 * #20 and #24 (duplicates) : indentation decrement not happening after a comment line
 * indentation decrement not happening when closing brace or parentheses after a line that contains a closing brace/parentheses inside either a comment or a string.
 * don't update indent of multi-line strings + restore indent for code after a multi-line string
 * fix wrong match of special include indentation for a case similar to #99

With all of those changes I'm now able to automatically indent a horrendous 7.9k-line file automatically with `gg=G` without any issues on indentation!