### PR TITLE
Highlight the asterisk as any other parameter.

### DIFF
--- a/syntax/puppet.vim
+++ b/syntax/puppet.vim
@@ -38,9 +38,9 @@ syn match   puppetInstance      "[A-Z][a-z_-]\+\(::[A-Z][a-z_-]\+\)*\s*<\?<|" co
 syn match   puppetTypeName      "[a-z]\w*" contained
 syn match   puppetTypeDefault   "[A-Z]\w*" contained
 
-syn match   puppetParam           "\w\+\s*\(=\|+\)>" contains=puppetTypeRArrow,puppetParamName
+syn match   puppetParam           "\(\w\+\|\*\)\s*\(=\|+\)>" contains=puppetTypeRArrow,puppetParamName
 syn match   puppetParamRArrow       "\(=\|+\)>" contained
-syn match   puppetParamName       "\w\+" contained contains=@NoSpell
+syn match   puppetParamName       "\(\w\+\|\*\)" contained contains=@NoSpell
 syn match   puppetVariable           "$\(\(\(::\)\?\w\+\)\+\|{\(\(::\)\?\w\+\)\+}\)"
 syn match   puppetParen           "("
 syn match   puppetParen           ")"


### PR DESCRIPTION
It always seems inconsistent to me not to highlight the asterisk in the following code:

```puppet
resource { 'name':
*     => $hash_of_parameters,
other => 'value',
}
```

This PR highlights the asterisk in the same way as the other parameter names.