### PR TITLE
Ftplugin fixups

### DIFF
--- a/autoload/puppet/format.vim
+++ b/autoload/puppet/format.vim
@@ -11,6 +11,8 @@ function! puppet#format#Format() abort
     call puppet#format#Hashrocket(l:start_lnum, l:end_lnum)
   endif
   call puppet#format#Fallback(l:start_lnum, l:end_lnum)
+  " explicitly avoid falling back to default formatting
+  return 0
 endfunction
 
 ""
@@ -40,10 +42,16 @@ endfunction
 " lines which exeed &widthline are formated
 "
 function! puppet#format#Fallback(start_lnum, end_lnum) abort
+  " We shouldn't wrap lines based on textwidth if it is disabled
+  if &textwidth == 0
+    return
+  endif
+
   " I'm using it to check if autoformat expand range
   let l:eof_lnum = line('$')
   let l:lnum = a:start_lnum
   let l:end_lnum = a:end_lnum
+
   while l:lnum <= l:end_lnum
     if strlen(getline(l:lnum)) > &textwidth
       call cursor(l:lnum)

--- a/autoload/puppet/format.vim
+++ b/autoload/puppet/format.vim
@@ -3,8 +3,13 @@
 function! puppet#format#Format() abort
   let l:start_lnum = v:lnum
   let l:end_lnum = v:lnum + v:count - 1
-  call puppet#format#Indention(l:start_lnum, l:end_lnum)
-  call puppet#format#Hashrocket(l:start_lnum, l:end_lnum)
+  " Don't modify indentation or alignment if called by textwidth. We'll only
+  " let the fallback function do its thing in this case so that textwidth
+  " still performs the expected feature.
+  if mode() !~# '[iR]'
+    call puppet#format#Indention(l:start_lnum, l:end_lnum)
+    call puppet#format#Hashrocket(l:start_lnum, l:end_lnum)
+  endif
   call puppet#format#Fallback(l:start_lnum, l:end_lnum)
 endfunction
 

--- a/ftplugin/puppet.vim
+++ b/ftplugin/puppet.vim
@@ -14,7 +14,7 @@ setlocal softtabstop=2
 setlocal shiftwidth=2
 setlocal expandtab
 setlocal keywordprg=puppet\ describe\ --providers
-setlocal iskeyword=-,:,@,48-57,_,192-255
+setlocal iskeyword=:,@,48-57,_,192-255
 setlocal comments=sr:/*,mb:*,ex:*/,b:#
 setlocal commentstring=#\ %s
 

--- a/ftplugin/puppet.vim
+++ b/ftplugin/puppet.vim
@@ -15,12 +15,13 @@ setlocal shiftwidth=2
 setlocal expandtab
 setlocal keywordprg=puppet\ describe\ --providers
 setlocal iskeyword=-,:,@,48-57,_,192-255
+setlocal comments=sr:/*,mb:*,ex:*/,b:#
 setlocal commentstring=#\ %s
 
 setlocal formatexpr=puppet#format#Format()
 
 let b:undo_ftplugin = "
     \ setlocal tabstop< tabstop< softtabstop< shiftwidth< expandtab<
-    \| setlocal keywordprg< iskeyword< commentstring<
+    \| setlocal keywordprg< iskeyword< comments< commentstring<
     \| setlocal formatexpr<
     \"

--- a/ftplugin/puppet.vim
+++ b/ftplugin/puppet.vim
@@ -18,10 +18,11 @@ setlocal iskeyword=:,@,48-57,_,192-255
 setlocal comments=sr:/*,mb:*,ex:*/,b:#
 setlocal commentstring=#\ %s
 
+setlocal formatoptions-=t formatoptions+=croql
 setlocal formatexpr=puppet#format#Format()
 
 let b:undo_ftplugin = "
     \ setlocal tabstop< tabstop< softtabstop< shiftwidth< expandtab<
     \| setlocal keywordprg< iskeyword< comments< commentstring<
-    \| setlocal formatexpr<
+    \| setlocal formatoptions< formatexpr<
     \"

--- a/ftplugin/puppet.vim
+++ b/ftplugin/puppet.vim
@@ -1,3 +1,14 @@
+" Vim filetype plugin
+" Language:             Puppet
+" Maintainer:           Tim Sharpe <tim@sharpe.id.au>
+" URL:                  https://github.com/rodjek/vim-puppet
+" Last Change:          2019-08-31
+
+if (exists("b:did_ftplugin"))
+  finish
+endif
+let b:did_ftplugin = 1
+
 setl ts=2
 setl sts=2
 setl sw=2

--- a/ftplugin/puppet.vim
+++ b/ftplugin/puppet.vim
@@ -9,10 +9,18 @@ if (exists("b:did_ftplugin"))
 endif
 let b:did_ftplugin = 1
 
-setl ts=2
-setl sts=2
-setl sw=2
-setl et
-setl keywordprg=puppet\ describe\ --providers
-setl iskeyword=-,:,@,48-57,_,192-255
-setl cms=#\ %s
+setlocal tabstop=2
+setlocal softtabstop=2
+setlocal shiftwidth=2
+setlocal expandtab
+setlocal keywordprg=puppet\ describe\ --providers
+setlocal iskeyword=-,:,@,48-57,_,192-255
+setlocal commentstring=#\ %s
+
+setlocal formatexpr=puppet#format#Format()
+
+let b:undo_ftplugin = "
+    \ setlocal tabstop< tabstop< softtabstop< shiftwidth< expandtab<
+    \| setlocal keywordprg< iskeyword< commentstring<
+    \| setlocal formatexpr<
+    \"

--- a/indent/puppet.vim
+++ b/indent/puppet.vim
@@ -12,7 +12,10 @@ let b:did_indent = 1
 setlocal autoindent smartindent
 setlocal indentexpr=GetPuppetIndent()
 setlocal indentkeys+=0],0)
-setlocal formatexpr=puppet#format#Format()
+
+let b:undo_indent = "
+    \ setlocal autoindent< smartindent< indentexpr< indentkeys<
+    \"
 
 if exists("*GetPuppetIndent")
     finish

--- a/test/format/hashrocket.vader
+++ b/test/format/hashrocket.vader
@@ -13,7 +13,7 @@ Expect (formated resource):
   }
 -------------------------------------------------------------------------------
 Given puppet (simple resource with gq):
-    # Long comment 123456789 123456789 123456789 123456789 123456789 123456789 123456789
+    # Short comment
   file { 'foo':
   ensure => present,
       force      =>     true,
@@ -23,8 +23,7 @@ Do (format resource):
   gqG
 
 Expect (formated resource):
-  # Long comment 123456789 123456789 123456789 123456789 123456789 123456789
-  # 123456789
+  # Short comment
   file { 'foo':
     ensure => present,
     force  => true,

--- a/test/format/textwidth.vader
+++ b/test/format/textwidth.vader
@@ -1,0 +1,32 @@
+Given puppet (long line):
+  # Long comment 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789
+  file { 'foo':
+    ensure => present,
+  }
+
+Do (format all text):
+  gqG
+
+Expect puppet (nothing changed):
+  # Long comment 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789
+  file { 'foo':
+    ensure => present,
+  }
+
+Before (set textwidth):
+  set textwidth=76
+
+After (unset textwidth):
+  set textwidth=0
+
+Do (format all text with textwidth set):
+  gqG
+
+Expect puppet (comment is wrapped into more lines):
+  # Long comment 123456789 123456789 123456789 123456789 123456789 123456789
+  # 123456789 123456789 123456789 123456789 123456789 123456789 123456789
+  # 123456789
+  file { 'foo':
+    ensure => present,
+  }
+


### PR DESCRIPTION
I've been working on some fixups for the ftplugin file.

most of them don't change much in the behaviour so I didn't think of any tests for them, except for the last commit which changes the behaviour of the formatting function (e.g. now requires textwidth to be set to a non-zero value in order to break up long lines).

some of the changes however remove some unknowns from (e.g. setting formatoptions) and to user config (e.g. cleaning up for ftplugin and indent teardown will avoid unwanted side-effects if users change the filetype of a buffer).

There's also some corrections to options that make the plugin better reflect current puppet behaviour (restricting comment styles to C-style and shell-style, and removing "-" from keywords)

This prepares the terrain for a bug fix for breaking up long lines on which I've been trying to work (but failed so far) and a new feature to get the "gf" and accompanying commands working -- I'll send another PR based on this one to try and get some help.