### PR TITLE
WIP: File include + fix format breaking up of long lines

### DIFF
--- a/autoload/puppet/format.vim
+++ b/autoload/puppet/format.vim
@@ -54,7 +54,12 @@ function! puppet#format#Fallback(start_lnum, end_lnum) abort
 
   while l:lnum <= l:end_lnum
     if strlen(getline(l:lnum)) > &textwidth
-      call cursor(l:lnum)
+      "... useless call?
+      "call cursor(l:lnum)
+      " XXX: this tends to invert the two last characters. the gww command
+      " can't place the cursor on the position that will contain v:char since
+      " it does not exist yet, so we get moved back by one column before
+      " v:char is added to the line.
       execute 'normal! gww'
       " Checking if autoformat expand number of lines if yes, I will extend
       " range too

--- a/autoload/puppet/format.vim
+++ b/autoload/puppet/format.vim
@@ -11,6 +11,8 @@ function! puppet#format#Format() abort
     call puppet#format#Hashrocket(l:start_lnum, l:end_lnum)
   endif
   call puppet#format#Fallback(l:start_lnum, l:end_lnum)
+  " explicitly avoid falling back to default formatting
+  return 0
 endfunction
 
 ""
@@ -40,10 +42,16 @@ endfunction
 " lines which exeed &widthline are formated
 "
 function! puppet#format#Fallback(start_lnum, end_lnum) abort
+  " We shouldn't wrap lines based on textwidth if it is disabled
+  if &textwidth == 0
+    return
+  endif
+
   " I'm using it to check if autoformat expand range
   let l:eof_lnum = line('$')
   let l:lnum = a:start_lnum
   let l:end_lnum = a:end_lnum
+
   while l:lnum <= l:end_lnum
     if strlen(getline(l:lnum)) > &textwidth
       call cursor(l:lnum)

--- a/autoload/puppet/format.vim
+++ b/autoload/puppet/format.vim
@@ -3,8 +3,13 @@
 function! puppet#format#Format() abort
   let l:start_lnum = v:lnum
   let l:end_lnum = v:lnum + v:count - 1
-  call puppet#format#Indention(l:start_lnum, l:end_lnum)
-  call puppet#format#Hashrocket(l:start_lnum, l:end_lnum)
+  " Don't modify indentation or alignment if called by textwidth. We'll only
+  " let the fallback function do its thing in this case so that textwidth
+  " still performs the expected feature.
+  if mode() !~# '[iR]'
+    call puppet#format#Indention(l:start_lnum, l:end_lnum)
+    call puppet#format#Hashrocket(l:start_lnum, l:end_lnum)
+  endif
   call puppet#format#Fallback(l:start_lnum, l:end_lnum)
 endfunction
 

--- a/autoload/puppet/include.vim
+++ b/autoload/puppet/include.vim
@@ -1,0 +1,19 @@
+function! puppet#include#IncludeExpr(fname) abort
+    " Remove puppet 3.x style leading :: since they mean nothing for the path
+    let l:fname = substitute(a:fname, '^::', '', '')
+
+    " If we can't find a second element, then we're referring to the init.pp
+    " file
+    if match(l:fname, '::') < 0
+        return 'init'
+    endif
+
+    " Remove first element. It'll make finding files easier since the module
+    " name might not be in the find path.
+    let l:fname = substitute(l:fname,'^[^:]\+::','','')
+
+    " Replace all subsequent :: in order to get a real file path
+    let l:fname = substitute(l:fname,'::','/','g')
+
+    return l:fname
+endfunction

--- a/ftplugin/puppet.vim
+++ b/ftplugin/puppet.vim
@@ -14,7 +14,7 @@ setlocal softtabstop=2
 setlocal shiftwidth=2
 setlocal expandtab
 setlocal keywordprg=puppet\ describe\ --providers
-setlocal iskeyword=-,:,@,48-57,_,192-255
+setlocal iskeyword=:,@,48-57,_,192-255
 setlocal comments=sr:/*,mb:*,ex:*/,b:#
 setlocal commentstring=#\ %s
 

--- a/ftplugin/puppet.vim
+++ b/ftplugin/puppet.vim
@@ -15,12 +15,13 @@ setlocal shiftwidth=2
 setlocal expandtab
 setlocal keywordprg=puppet\ describe\ --providers
 setlocal iskeyword=-,:,@,48-57,_,192-255
+setlocal comments=sr:/*,mb:*,ex:*/,b:#
 setlocal commentstring=#\ %s
 
 setlocal formatexpr=puppet#format#Format()
 
 let b:undo_ftplugin = "
     \ setlocal tabstop< tabstop< softtabstop< shiftwidth< expandtab<
-    \| setlocal keywordprg< iskeyword< commentstring<
+    \| setlocal keywordprg< iskeyword< comments< commentstring<
     \| setlocal formatexpr<
     \"

--- a/ftplugin/puppet.vim
+++ b/ftplugin/puppet.vim
@@ -18,10 +18,11 @@ setlocal iskeyword=:,@,48-57,_,192-255
 setlocal comments=sr:/*,mb:*,ex:*/,b:#
 setlocal commentstring=#\ %s
 
+setlocal formatoptions-=t formatoptions+=croql
 setlocal formatexpr=puppet#format#Format()
 
 let b:undo_ftplugin = "
     \ setlocal tabstop< tabstop< softtabstop< shiftwidth< expandtab<
     \| setlocal keywordprg< iskeyword< comments< commentstring<
-    \| setlocal formatexpr<
+    \| setlocal formatoptions< formatexpr<
     \"

--- a/ftplugin/puppet.vim
+++ b/ftplugin/puppet.vim
@@ -1,3 +1,14 @@
+" Vim filetype plugin
+" Language:             Puppet
+" Maintainer:           Tim Sharpe <tim@sharpe.id.au>
+" URL:                  https://github.com/rodjek/vim-puppet
+" Last Change:          2019-08-31
+
+if (exists("b:did_ftplugin"))
+  finish
+endif
+let b:did_ftplugin = 1
+
 setl ts=2
 setl sts=2
 setl sw=2

--- a/ftplugin/puppet.vim
+++ b/ftplugin/puppet.vim
@@ -21,8 +21,13 @@ setlocal commentstring=#\ %s
 setlocal formatoptions-=t formatoptions+=croql
 setlocal formatexpr=puppet#format#Format()
 
+setlocal suffixesadd=.pp
+setlocal include=\\v^\\s*(include\|contain\|class\\s+\\\{\|Class\\s+\\\[)\\s+[\"\']?\\zs(\\f\|::)+
+setlocal includeexpr=puppet#include#IncludeExpr(v:fname)
+
 let b:undo_ftplugin = "
     \ setlocal tabstop< tabstop< softtabstop< shiftwidth< expandtab<
     \| setlocal keywordprg< iskeyword< comments< commentstring<
     \| setlocal formatoptions< formatexpr<
+    \| setlocal suffixesadd< include< includeexpr<
     \"

--- a/ftplugin/puppet.vim
+++ b/ftplugin/puppet.vim
@@ -9,10 +9,18 @@ if (exists("b:did_ftplugin"))
 endif
 let b:did_ftplugin = 1
 
-setl ts=2
-setl sts=2
-setl sw=2
-setl et
-setl keywordprg=puppet\ describe\ --providers
-setl iskeyword=-,:,@,48-57,_,192-255
-setl cms=#\ %s
+setlocal tabstop=2
+setlocal softtabstop=2
+setlocal shiftwidth=2
+setlocal expandtab
+setlocal keywordprg=puppet\ describe\ --providers
+setlocal iskeyword=-,:,@,48-57,_,192-255
+setlocal commentstring=#\ %s
+
+setlocal formatexpr=puppet#format#Format()
+
+let b:undo_ftplugin = "
+    \ setlocal tabstop< tabstop< softtabstop< shiftwidth< expandtab<
+    \| setlocal keywordprg< iskeyword< commentstring<
+    \| setlocal formatexpr<
+    \"

--- a/indent/puppet.vim
+++ b/indent/puppet.vim
@@ -12,7 +12,10 @@ let b:did_indent = 1
 setlocal autoindent smartindent
 setlocal indentexpr=GetPuppetIndent()
 setlocal indentkeys+=0],0)
-setlocal formatexpr=puppet#format#Format()
+
+let b:undo_indent = "
+    \ setlocal autoindent< smartindent< indentexpr< indentkeys<
+    \"
 
 if exists("*GetPuppetIndent")
     finish

--- a/test/format/hashrocket.vader
+++ b/test/format/hashrocket.vader
@@ -13,7 +13,7 @@ Expect (formated resource):
   }
 -------------------------------------------------------------------------------
 Given puppet (simple resource with gq):
-    # Long comment 123456789 123456789 123456789 123456789 123456789 123456789 123456789
+    # Short comment
   file { 'foo':
   ensure => present,
       force      =>     true,
@@ -23,8 +23,7 @@ Do (format resource):
   gqG
 
 Expect (formated resource):
-  # Long comment 123456789 123456789 123456789 123456789 123456789 123456789
-  # 123456789
+  # Short comment
   file { 'foo':
     ensure => present,
     force  => true,

--- a/test/format/textwidth.vader
+++ b/test/format/textwidth.vader
@@ -1,0 +1,32 @@
+Given puppet (long line):
+  # Long comment 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789
+  file { 'foo':
+    ensure => present,
+  }
+
+Do (format all text):
+  gqG
+
+Expect puppet (nothing changed):
+  # Long comment 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789
+  file { 'foo':
+    ensure => present,
+  }
+
+Before (set textwidth):
+  set textwidth=76
+
+After (unset textwidth):
+  set textwidth=0
+
+Do (format all text with textwidth set):
+  gqG
+
+Expect puppet (comment is wrapped into more lines):
+  # Long comment 123456789 123456789 123456789 123456789 123456789 123456789
+  # 123456789 123456789 123456789 123456789 123456789 123456789 123456789
+  # 123456789
+  file { 'foo':
+    ensure => present,
+  }
+

--- a/test/format/textwidth.vader
+++ b/test/format/textwidth.vader
@@ -29,4 +29,51 @@ Expect puppet (comment is wrapped into more lines):
   file { 'foo':
     ensure => present,
   }
+-------------------------------------------------------------------------------
+Given puppet (long line before editing):
+  file { 'foo':
+    ensure => present,
+    source => ['puppet:///modules/very_long_module_name_that_will_not_stop'],
+  }
+
+Before (set textwidth):
+  set textwidth=76
+
+After (unset textwidth):
+  set textwidth=0
+
+Do (type in some more on long line):
+  jjA mode
+
+Expect puppet (text is wrapped to new line):
+  file { 'foo':
+    ensure => present,
+    source => ['puppet:///modules/very_long_module_name_that_will_not_stop'],
+    mode
+  }
+-------------------------------------------------------------------------------
+-- This next test is paired with a functionality that should be made better
+-- By keeping the cursor in the relative same spot, we could actually run
+-- indent and hashrocket formatting.
+Given puppet (badly indented long line before editing):
+  file { 'foo':
+    ensure => present,
+  source => ['puppet:///modules/very_long_module_name_that_will_not_stopXX'],
+  }
+
+Before (set textwidth):
+  set textwidth=76
+
+After (unset textwidth):
+  set textwidth=0
+
+Do (type in some more on long line):
+  jjAmode
+
+Expect puppet (text is wrapped to new line without reindenting):
+  file { 'foo':
+    ensure => present,
+  source => ['puppet:///modules/very_long_module_name_that_will_not_stopXX'],
+  mode
+  }
 


### PR DESCRIPTION
This patchset is based off of #113 

I've been trying to fix an annoying bug that affects users with `textwidth` set: when reaching the point where a line is long enough, `puppet#format#Format` gets called and the underlying command that's currently used flips the two last characters. I've detailed why this is happening in a comment in `auto/puppet/format.vim`.
I've so far tried a couple different approaches to fix this up and none worked.
I'm wondering if we'd be better off here deciding to disable this line-breaking function for the "i" and "R" modes so that lines don't get broken up as you type but would rather require users to use the `gq` command to format long lines correctly.
I'm wondering if others have better ideas about this bug though.

The other thing in this patchset that I've tried to do and mostly accomplished is to setup `include` and `includeexpr` so that users can go on jumping from all references to another class/defined type to the actual file defining it.
I've hit a roadblock while implementing this though: say that you have a line that reads `contain ganeti::config`, when typing the `gf` command while the cursor is on the word "ganeti", vim doesn't consider the whole class name and jumps to the file "init.pp" unexpectedly.
a simliar thing happens if you have more than one part to the class name. for example if you had `include apache::vhost::php`, typing `gf` while the cursor is on "php" would try to find the file `php.pp` instead of `vhost/php.pp`.
I'm not sure why the `includeexpr` is not getting more than one part of the class name.