### PR TITLE
Detect and highlight epp syntax

### DIFF
--- a/ftdetect/puppet.vim
+++ b/ftdetect/puppet.vim
@@ -1,2 +1,3 @@
-au! BufRead,BufNewFile *.pp,*.epp setfiletype puppet
+au! BufRead,BufNewFile *.pp setfiletype puppet
+au! BufRead,BufNewFile *.epp setfiletype embeddedpuppet
 au! BufRead,BufNewFile Puppetfile setfiletype ruby

--- a/ftplugin/embeddedpuppet.vim
+++ b/ftplugin/embeddedpuppet.vim
@@ -1,0 +1,75 @@
+" Vim filetype plugin
+" Language:             embedded puppet
+" Maintainer:           Gabriel Filion <gabster@lelutin.ca>
+" URL:                  https://github.com/rodjek/vim-puppet
+" Last Change:          2019-09-01
+
+" Only do this when not done yet for this buffer
+if exists("b:did_ftplugin")
+  finish
+endif
+
+let s:save_cpo = &cpo
+set cpo-=C
+
+" Define some defaults in case the included ftplugins don't set them.
+let s:undo_ftplugin = ""
+let s:browsefilter = "All Files (*.*)\t*.*\n"
+let s:match_words = ""
+
+runtime! ftplugin/sh.vim
+unlet! b:did_ftplugin
+
+" Override our defaults if these were set by an included ftplugin.
+if exists("b:undo_ftplugin")
+  let s:undo_ftplugin = b:undo_ftplugin
+  unlet b:undo_ftplugin
+endif
+if exists("b:browsefilter")
+  let s:browsefilter = b:browsefilter
+  unlet b:browsefilter
+endif
+if exists("b:match_words")
+  let s:match_words = b:match_words
+  unlet b:match_words
+endif
+
+let s:include = &l:include
+let s:path = &l:path
+let s:suffixesadd = &l:suffixesadd
+
+runtime! ftplugin/puppet.vim
+let b:did_ftplugin = 1
+
+" Combine the new set of values with those previously included.
+if exists("b:undo_ftplugin")
+  let s:undo_ftplugin = b:undo_ftplugin . " | " . s:undo_ftplugin
+endif
+if exists ("b:browsefilter")
+  let s:browsefilter = substitute(b:browsefilter,'\cAll Files (\*\.\*)\t\*\.\*\n','','') . s:browsefilter
+endif
+if exists("b:match_words")
+  let s:match_words = b:match_words . ',' . s:match_words
+endif
+
+if len(s:include)
+  let &l:include = s:include
+endif
+let &l:path = s:path . (s:path =~# ',$\|^$' ? '' : ',') . &l:path
+let &l:suffixesadd = s:suffixesadd . (s:suffixesadd =~# ',$\|^$' ? '' : ',') . &l:suffixesadd
+unlet s:include s:path s:suffixesadd
+
+" Load the combined list of match_words for matchit.vim
+if exists("loaded_matchit")
+  let b:match_words = s:match_words
+endif
+
+" TODO: comments=
+setlocal commentstring=<%#%s%>
+
+let b:undo_ftplugin = "setl cms< "
+      \ " | unlet! b:browsefilter b:match_words | " . s:undo_ftplugin
+
+let &cpo = s:save_cpo
+unlet s:save_cpo
+

--- a/syntax/embeddedpuppet.vim
+++ b/syntax/embeddedpuppet.vim
@@ -1,0 +1,29 @@
+" Vim filetype plugin
+" Language:             embedded puppet
+" Maintainer:           Gabriel Filion <gabster@lelutin.ca>
+" URL:                  https://github.com/rodjek/vim-puppet
+" Last Change:          2019-09-01
+
+" quit when a syntax file was already loaded {{{1
+if exists("b:current_syntax")
+  finish
+endif
+
+runtime! syntax/sh.vim
+unlet! b:current_syntax
+
+syn include @puppetTop syntax/puppet.vim
+
+syn cluster ePuppetRegions contains=ePuppetBlock,ePuppetExpression,ePuppetComment
+
+syn region  ePuppetBlock      matchgroup=ePuppetDelimiter start="<%%\@!-\=" end="[=-]\=%\@<!%>" contains=@puppetTop  containedin=ALLBUT,@ePuppetRegions keepend
+syn region  ePuppetExpression matchgroup=ePuppetDelimiter start="<%=\{1,4}" end="[=-]\=%\@<!%>" contains=@puppetTop  containedin=ALLBUT,@ePuppetRegions keepend
+syn region  ePuppetComment    matchgroup=ePuppetDelimiter start="<%-\=#"    end="[=-]\=%\@<!%>" contains=puppetTodo,@Spell containedin=ALLBUT,@ePuppetRegions keepend
+
+" Define the default highlighting.
+
+hi def link ePuppetDelimiter              PreProc
+hi def link ePuppetComment                Comment
+
+let b:current_syntax = "embeddedpuppet"
+

--- a/syntax/embeddedpuppet.vim
+++ b/syntax/embeddedpuppet.vim
@@ -1,4 +1,4 @@
-" Vim filetype plugin
+" Vim syntax plugin
 " Language:             embedded puppet
 " Maintainer:           Gabriel Filion <gabster@lelutin.ca>
 " URL:                  https://github.com/rodjek/vim-puppet

--- a/test/syntax/embeddedpuppet.vader
+++ b/test/syntax/embeddedpuppet.vader
@@ -1,0 +1,35 @@
+Given embeddedpuppet (template with litteral content puppet tags):
+  # Short litteral comment
+  <% if $variable == '<%%somevalue%%>' { -%>
+  MYVAR=<%= $variable %>
+    <%- if $more_variable {
+  # This is a puppet comment -%>
+  MOREVAR=true
+    <%- } %>
+  <%# epp comment with TODO mark %>
+
+Execute (litteral content syntax must be correct):
+  AssertEqual 'shComment', SyntaxOf('litteral comment')
+  AssertEqual 'shVariable', SyntaxOf('MYVAR')
+
+Execute (epp delimiter syntax must be correct):
+-- The error messages here are super confusing since all of the assertions use
+-- the same type. This is a shortcoming of the current vader output. To bypass
+-- this, let's define our own message.
+  AssertEqual 'ePuppetDelimiter', SyntaxOf('<%'), "syntax of <% should be 'ePuppetDelimiter', got '".SyntaxOf('<%')."'"
+  AssertEqual 'ePuppetDelimiter', SyntaxOf('-%>'), "syntax of -%> should be 'ePuppetDelimiter', got '".SyntaxOf('-%>')."'"
+  AssertEqual 'ePuppetDelimiter', SyntaxOf('<%-'), "syntax of <%- should be 'ePuppetDelimiter', got '".SyntaxOf('<%-')."'"
+  AssertEqual 'ePuppetComment', SyntaxOf('epp comment')
+-- We're testing for a *puppet* syntax here but that's because it's contained
+-- in the ePuppetComment syntax region
+  AssertEqual 'puppetTodo', SyntaxOf('TODO')
+
+Execute (puppet syntax must be correct):
+  AssertEqual 'puppetControl', SyntaxOf('if')
+  AssertEqual 'puppetVariable', SyntaxOf('$variable')
+-- Again, we're testing multiple times for the same syntaxID. Let's define our
+-- message.
+  AssertEqual 'puppetBrace', SyntaxOf('{'), "for { in first puppet block, expected 'puppetBrace', got '".SyntaxOf('{')."'"
+  AssertEqual 'puppetBrace', SyntaxOf('{', 2), "for { in second puppet block, expected 'puppetBrace', got '".SyntaxOf('{', 2)."'"
+  AssertEqual 'puppetBrace', SyntaxOf('}'), "for } in third puppet block, expected 'puppetBrace', got '".SyntaxOf('}')."'"
+  AssertEqual 'puppetComment', SyntaxOf('puppet comment')


### PR DESCRIPTION
This is a replacement for #63. I've started by merging @rothsa 's work and seeing that it did somewhat work, it then motivated me to continue on that direction and actually get full syntax hilghlighting for `.epp` files.

I've base my work by heavily re-using what Tim Pope did for eruby, but with lots of complexity removed.

I've taken a shortcut here by assuming that the underlying syntax (e.g. what's used for the template's litteral content) is colored using "sh" filetype. That choice was made so that I could implement this faster, but also both because the sh filetype should cover a good majority of content in templates somewhat correctly and that it's actually quite hard to detect what type of content a puppet template is supposed to represent (e.g. no consistently available information from the file name, from a header or from a comment somewhere)

I've also added a test that should check most colouring cases to make sure that epp syntax highlighting is unbroken with future changes.