### PR TITLE
add tag for class name with leading colons

### DIFF
--- a/ctags/puppet.ctags
+++ b/ctags/puppet.ctags
@@ -1,10 +1,11 @@
 --langdef=puppet
 --langmap=puppet:.pp
+--regex-puppet=/^[[:space:]]*class[[:space:]]*([a-z][a-zA-Z0-9_:\-]+)/::\1/c,class/
 --regex-puppet=/^[[:space:]]*class[[:space:]]*([a-z][a-zA-Z0-9_:\-]+)/\1/c,class/
 --regex-puppet=/^[[:space:]]*site[[:space:]]*([a-zA-Z0-9_\-]+)/\1/s,site/
 --regex-puppet=/^[[:space:]]*node[[:space:]]*[\'|\"]*([a-zA-Z0-9_\.\-]+)[\'|\"]*/\1/n,node/
 --regex-puppet=/^[[:space:]]*define[[:space:]]*([a-z][a-zA-Z0-9_:\-]+)/\1/d,definition/
---regex-puppet=/^[[:space:]]*(include|require)[[:space:]]*([a-zA-Z0-9_:]+)/\1 \2/i,include/
+--regex-puppet=/^[[:space:]]*(include|require)[[:space:]]*:{0,2}([a-zA-Z0-9_:]+)/\1 ::\2/i,include/
 --regex-puppet=/^[[:space:]]*([\$][a-zA-Z0-9_:]+)[[:space:]]*=/\1/v,variable/
 --regex-puppet=/^[[:space:]]*[~|\-]?>?[[:space:]]*([a-z][a-zA-Z0-9_:]+)[[:space:]]*\{ *(.*):/\1[\2]/r,resource/
 --regex-puppet=/([A-Z][a-zA-Z0-9_:]+)[[:space:]]*\{/\1/f,default/


### PR DESCRIPTION
this makes the following work as expected:

```puppet
include ::foo::bar::baz
```

Fixes #122