### PR TITLE
Don't delete all autocmds when reading or opening a file

### DIFF
--- a/ftdetect/puppet.vim
+++ b/ftdetect/puppet.vim
@@ -1,3 +1,3 @@
-au! BufRead,BufNewFile *.pp setfiletype puppet
-au! BufRead,BufNewFile *.epp setfiletype embeddedpuppet
-au! BufRead,BufNewFile Puppetfile setfiletype ruby
+au BufRead,BufNewFile *.pp setfiletype puppet
+au BufRead,BufNewFile *.epp setfiletype embeddedpuppet
+au BufRead,BufNewFile Puppetfile setfiletype ruby


### PR DESCRIPTION
The effect of the ! after the au keyword is that all autocommands get
removed and then this one gets added.

This could potentially hide some other autocommands that would be
supplied by other plugins or user scripts that get loaded before this
plugin.

As far as I can see, other plugins that set the filetype don't use the !
after au.