### PR TITLE
add mention of vim-yardoc and lint the readme file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,9 @@ install:
     set -e
     pushd /tmp
     if [ "$TESTVIM" = nvim ]; then
-      eval "$(curl -Ss https://raw.githubusercontent.com/neovim/bot-ci/master/scripts/travis-setup.sh) nightly-x64"
-      gem install neovim
-      pip install --user neovim
+      curl -LO https://github.com/neovim/neovim/releases/download/v0.4.4/nvim-linux64.tar.gz
+      tar xzf nvim-linux64.tar.gz
+      export PATH="${PATH}:node_modules/.bin:$(pwd)/nvim-linux64/bin"
     fi
     popd
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ Provides
 Additional useful plugins
 -------------------------
 
+ * [vim-yardoc](https://github.com/noprompt/vim-yardoc) Syntax coloration for
+     YARD tags and directives. It can also colorize the tags and directives in
+     puppet files.
  * [syntastic](https://github.com/scrooloose/syntastic) plugin for automatic
    syntax checking while in vim.
  * [vim-snippets](https://github.com/honza/vim-snippets) is a library of

--- a/README.md
+++ b/README.md
@@ -9,38 +9,38 @@ Make vim more Puppet friendly!
 Provides
 --------
 
-  * Formatting based on the latest Puppetlabs Style Guide
-  * Syntax highlighting compatible with puppet 4.x
-  * Automatic => alignment
-    * If you don't like that, add `let g:puppet_align_hashes = 0` to your vimrc.
-  * Ctags support
-  * Doesn't require a bloated JRE
-  * Doesn't take minutes to open
+* Formatting based on the latest Puppetlabs Style Guide
+* Syntax highlighting compatible with puppet 4.x
+* Automatic => alignment
+  * If you don't like that, add `let g:puppet_align_hashes = 0` to your vimrc.
+* Ctags support
+* Doesn't require a bloated JRE
+* Doesn't take minutes to open
 
 Additional useful plugins
 -------------------------
 
- * [vim-yardoc](https://github.com/noprompt/vim-yardoc) Syntax coloration for
-     YARD tags and directives. It can also colorize the tags and directives in
-     puppet files.
- * [syntastic](https://github.com/scrooloose/syntastic) plugin for automatic
+* [vim-yardoc](https://github.com/noprompt/vim-yardoc) Syntax coloration for
+  YARD tags and directives. It can also colorize the tags and directives in
+  puppet files.
+* [syntastic](https://github.com/scrooloose/syntastic) plugin for automatic
    syntax checking while in vim.
- * [vim-snippets](https://github.com/honza/vim-snippets) is a library of
-   snippets for multiple languages, including Puppet. Works with both
-   [snipmate](https://github.com/garbas/vim-snipmate) and
-   [ultisnips](https://github.com/SirVer/ultisnips).
- * [Tagbar](https://github.com/majutsushi/tagbar) plugin for Ctags support.
+* [vim-snippets](https://github.com/honza/vim-snippets) is a library of
+  snippets for multiple languages, including Puppet. Works with both
+  [snipmate](https://github.com/garbas/vim-snipmate) and
+  [ultisnips](https://github.com/SirVer/ultisnips).
+* [Tagbar](https://github.com/majutsushi/tagbar) plugin for Ctags support.
 
 Installation
 ------------
 
-If you're using [pathogen](https://github.com/tpope/vim-pathogen) to manage your vim modules (and if you're not, why
-aren't you), you can simply add this as a submodule in your `~/.vim/bundle/`
-directory.
+If you're using [pathogen](https://github.com/tpope/vim-pathogen) to manage
+your vim modules (and if you're not, why aren't you), you can simply add this
+as a submodule in your `~/.vim/bundle/` directory.
 
 My entire home directory is a git repository, so for me it's simply a case of
 
-    $ git submodule add -f git://github.com/rodjek/vim-puppet.git .vim/bundle/puppet
+    git submodule add -f git://github.com/rodjek/vim-puppet.git .vim/bundle/puppet
 
 If you're not using pathogen, you can just manually place the files in the
 appropriate places under `~/.vim/`
@@ -48,4 +48,8 @@ appropriate places under `~/.vim/`
 Testing
 -------
 
-Testing is based on vader.vim testing framework, see: https://github.com/junegunn/vader.vim . To run full test suit use `./test/run-tests.sh`, this will also download vader.vim plugin to project's folder.
+Testing is based on vader.vim testing framework, see:
+<https://github.com/junegunn/vader.vim> . To run full test suit use
+`./test/run-tests.sh`, this will also download vader.vim plugin to project's
+folder.
+


### PR DESCRIPTION
This series doesn't have an impact on the plugin's code. Since the change suggested in #125 was merged in vim-yardoc we can now add it as a suggested additional plugin.

I've also started using markdownlint and it'll help keep things more tidy in the file