### PR TITLE
Add syntax fold support

### DIFF
--- a/syntax/puppet.vim
+++ b/syntax/puppet.vim
@@ -28,9 +28,9 @@ syn match  puppetOperator "+=\|-=\|==\|!=\|=\~\|!\~\|>=\|<=\|<-\|<\~\|=>\|+>\|->
 " three character operators
 syn match  puppetOperator "<<|\||>>"
 
-syn region puppetBracketOperator matchgroup=puppetDelimiter start="\[\s*" end="\s*]" contains=ALLBUT,@puppetNotTop
-syn region puppetBraceOperator matchgroup=puppetDelimiter start="{\s*" end="\s*}" contains=ALLBUT,@puppetNotTop
-syn region puppetParenOperator matchgroup=puppetDelimiter start="(\s*" end="\s*)" contains=ALLBUT,@puppetNotTop
+syn region puppetBracketOperator matchgroup=puppetDelimiter start="\[\s*" end="\s*]" fold contains=ALLBUT,@puppetNotTop
+syn region puppetBraceOperator matchgroup=puppetDelimiter start="{\s*" end="\s*}" fold contains=ALLBUT,@puppetNotTop
+syn region puppetParenOperator matchgroup=puppetDelimiter start="(\s*" end="\s*)" fold contains=ALLBUT,@puppetNotTop
 
 " Expression Substitution and Backslash Notation {{{1
 syn match puppetStringEscape "\\\\\|\\[abefnrstv]\|\\\o\{1,3}\|\\x\x\{1,2}" contained display

--- a/test/syntax/fold.vader
+++ b/test/syntax/fold.vader
@@ -1,0 +1,25 @@
+Before:
+  setlocal foldmethod=syntax
+
+After:
+  setlocal foldmethod=manual
+
+Given puppet (basic class):
+  class foobar(
+    $a = true
+  ) {
+    $b = true
+    if $b {
+      $c = false
+    }
+  }
+
+Execute (fold level # in code block):
+  AssertEqual foldlevel(1), 1, 'class foobar('
+  AssertEqual foldlevel(2), 1, '  $a = true'
+  AssertEqual foldlevel(3), 1, ') {'
+  AssertEqual foldlevel(4), 1, '  $b = false'
+  AssertEqual foldlevel(5), 2, '  if $b {'
+  AssertEqual foldlevel(6), 2, '    $c = false'
+  AssertEqual foldlevel(7), 2, '  }'
+  AssertEqual foldlevel(8), 1, '}'


### PR DESCRIPTION
This uses the existing `region`s defined in the syntax file to provide fold support when `foldmethod = syntax`.

Before:
![before_fold](https://user-images.githubusercontent.com/3103817/105675573-0a8f4900-5f35-11eb-9a8d-edf432b4d179.png)

After (with top-level fold opened):
![fold_after](https://user-images.githubusercontent.com/3103817/105675597-11b65700-5f35-11eb-872e-f28c24d15a7c.png)
