### PR TITLE
Detect original filetype of an embedded puppet file

### DIFF
--- a/ftdetect/puppet.lua
+++ b/ftdetect/puppet.lua
@@ -1,0 +1,16 @@
+-- Some epp files may get marked as "mason" type before this script is reached.
+-- Vim's own scripts.vim forces the type if it detects a `<%` at the start of
+-- the file. All files ending in .epp should be epuppet
+vim.filetype.add({
+    extension = {
+        epp =
+            function(path, bufnr)
+                path_wo_epp = path:sub(1,-5)
+                matched = vim.filetype.match({ buf = bufnr, filename = path_wo_epp })
+                if matched ~= nil and matched ~= 'mason' then
+                    vim.b.original_filetype = matched
+                end
+                return 'epuppet'
+            end,
+    }
+})

--- a/ftdetect/puppet.vim
+++ b/ftdetect/puppet.vim
@@ -11,5 +11,12 @@ au! BufRead,BufNewFile *.pp setfiletype puppet
 " Some epp files may get marked as "mason" type before this script is reached.
 " Vim's own scripts.vim forces the type if it detects a `<%` at the start of
 " the file. All files ending in .epp should be epuppet
-au BufRead,BufNewFile *.epp setl ft=epuppet
+autocmd BufRead,BufNewFile *.epp call DetectOriginalType()
+function! DetectOriginalType()
+    execute 'doautocmd filetypedetect BufRead ' .fnameescape(expand('<afile>:r'))
+    if &filetype !=# '' && !( &filetype ==# 'mason' && expand('<afile>') !~# 'mason')
+        let b:original_filetype = &filetype
+    endif
+    setlocal filetype=epuppet
+endfunction
 au BufRead,BufNewFile Puppetfile setfiletype ruby

--- a/ftdetect/puppet.vim
+++ b/ftdetect/puppet.vim
@@ -11,12 +11,14 @@ au! BufRead,BufNewFile *.pp setfiletype puppet
 " Some epp files may get marked as "mason" type before this script is reached.
 " Vim's own scripts.vim forces the type if it detects a `<%` at the start of
 " the file. All files ending in .epp should be epuppet
-autocmd! BufRead,BufNewFile *.epp call DetectOriginalType()
-function! DetectOriginalType()
-    execute 'doautocmd filetypedetect BufRead ' .fnameescape(expand('<afile>:r'))
-    if &filetype !=# '' && !( &filetype ==# 'mason' && expand('<afile>') !~# 'mason')
-        let b:original_filetype = &filetype
-    endif
-    setlocal filetype=epuppet
-endfunction
+if !has('nvim-0.8.0')
+    autocmd! BufRead,BufNewFile *.epp call DetectOriginalType()
+    function! DetectOriginalType()
+        execute 'doautocmd filetypedetect BufRead ' .fnameescape(expand('<afile>:r'))
+        if &filetype !=# '' && !( &filetype ==# 'mason' && expand('<afile>') !~# 'mason')
+            let b:original_filetype = &filetype
+        endif
+        setlocal filetype=epuppet
+    endfunction
+endif
 au BufRead,BufNewFile Puppetfile setfiletype ruby

--- a/ftdetect/puppet.vim
+++ b/ftdetect/puppet.vim
@@ -11,7 +11,7 @@ au! BufRead,BufNewFile *.pp setfiletype puppet
 " Some epp files may get marked as "mason" type before this script is reached.
 " Vim's own scripts.vim forces the type if it detects a `<%` at the start of
 " the file. All files ending in .epp should be epuppet
-autocmd BufRead,BufNewFile *.epp call DetectOriginalType()
+autocmd! BufRead,BufNewFile *.epp call DetectOriginalType()
 function! DetectOriginalType()
     execute 'doautocmd filetypedetect BufRead ' .fnameescape(expand('<afile>:r'))
     if &filetype !=# '' && !( &filetype ==# 'mason' && expand('<afile>') !~# 'mason')

--- a/syntax/epuppet.vim
+++ b/syntax/epuppet.vim
@@ -9,7 +9,13 @@ if exists('b:current_syntax')
   finish
 endif
 
-runtime! syntax/sh.vim
+if exists('b:original_filetype')
+    runtime! syntax/'.b:original_filetype .'.vim'
+    " allow original filetype detection by other plugins like ale or coc.nvim
+    let &filetype=b:original_filetype .'.epuppet'
+else
+    runtime! syntax/sh.vim
+endif
 unlet! b:current_syntax
 
 syn include @puppetTop syntax/puppet.vim
@@ -25,5 +31,9 @@ syn region  ePuppetComment    matchgroup=ePuppetDelimiter start="<%-\=#"    end=
 hi def link ePuppetDelimiter              PreProc
 hi def link ePuppetComment                Comment
 
-let b:current_syntax = 'epuppet'
+if exists('b:original_filetype')
+    let b:current_syntax = b:original_filetype . '.epuppet'
+else
+    let b:current_syntax = 'epuppet'
+endif
 

--- a/test/filetype/epuppet.vader
+++ b/test/filetype/epuppet.vader
@@ -2,13 +2,26 @@ Execute (Filetype detection on a new empty file):
   edit foo.epp
   AssertEqual &filetype, 'epuppet'
 
-Given (epuppet file with leading tag):
-  <% if { %>
-  content
-
-Execute (trigger filetype detection):
-  file test_with_leading_tag.epp
-  edit
-
-Then (should be detected as epuppet):
+Execute (epuppet test_with_leading_tag):
+  edit test/test-files/test_with_leading_tag.epp
   AssertEqual &filetype, 'epuppet'
+
+Execute (epuppet perl with shebang):
+  edit test/test-files/test_perl_with_shebang.epp
+  AssertEqual &filetype, 'perl.epuppet'
+
+Execute (epuppet shell with shebang):
+  edit test/test-files/test_shell_with_shebang.epp
+  AssertEqual &filetype, 'sh.epuppet'
+
+Execute (epuppet shell with extension):
+  edit test/test-files/test_shell_with_extension.sh.epp
+  AssertEqual &filetype, 'sh.epuppet'
+
+Execute (epuppet php with extension):
+  edit test/test-files/test_php_with_extension.php.epp
+  AssertEqual &filetype, 'php.epuppet'
+
+Execute (epuppet apache conf with path and extension):
+  edit test/test-files/etc/apache2/test.conf.epp
+  AssertEqual &filetype, 'apache.epuppet'

--- a/test/filetype/puppet.vader
+++ b/test/filetype/puppet.vader
@@ -1,12 +1,5 @@
-Given (simple puppet file):
-  # comment
-  class module::thisclass {
-    # ... do something
-  }
-
-Execute (trigger filetype detection):
-  file simple.pp
-  edit
+Execute (Load simple puppet file):
+  edit simple.pp
 
 Then (Detected simple.pp as a puppet file):
   AssertEqual &filetype, 'puppet'

--- a/test/filetype/puppetfile.vader
+++ b/test/filetype/puppetfile.vader
@@ -1,11 +1,5 @@
-Given (simple Puppetfile):
-  forge "https://forgeapi.puppetlabs.com"
-  # comment
-  mod 'username-modulename', '1.2.3'
-
-Execute (trigger filetype detection):
-  file Puppetfile
-  edit
+Execute (Load Puppetfile):
+  edit test/test-files/Puppetfile
 
 Then (Detected Puppetfile as a ruby file):
   AssertEqual &filetype, 'ruby'

--- a/test/test-files/Puppetfile
+++ b/test/test-files/Puppetfile
@@ -1,0 +1,3 @@
+forge "https://forgeapi.puppetlabs.com"
+# comment
+mod 'username-modulename', '1.2.3'

--- a/test/test-files/etc/apache2/test.conf.epp
+++ b/test/test-files/etc/apache2/test.conf.epp
@@ -1,0 +1,4 @@
+# conf
+<VirtualHost *:80>
+    ServerName example.com
+</VirtualHost>

--- a/test/test-files/simple.pp
+++ b/test/test-files/simple.pp
@@ -1,0 +1,4 @@
+# comment
+class module::thisclass {
+  # ... do something
+}

--- a/test/test-files/test_perl_with_shebang.epp
+++ b/test/test-files/test_perl_with_shebang.epp
@@ -1,0 +1,4 @@
+#!/usr/bin/perl
+use strict;
+use warning;
+print "<%= $variable %>";

--- a/test/test-files/test_php_with_extension.php.epp
+++ b/test/test-files/test_php_with_extension.php.epp
@@ -1,0 +1,7 @@
+<?php
+
+if ($a == 1) {
+    # code...
+    echo $coin;
+    echo "<%= $meuh %>";
+}

--- a/test/test-files/test_shell_with_extension.sh.epp
+++ b/test/test-files/test_shell_with_extension.sh.epp
@@ -1,0 +1,3 @@
+if [ -t bla ]; then
+  echo <%= $bla %>
+fi

--- a/test/test-files/test_shell_with_shebang.epp
+++ b/test/test-files/test_shell_with_shebang.epp
@@ -1,0 +1,4 @@
+#!/bin/bash
+if [ -t bla ]; then
+  echo <%= $bla %>
+fi

--- a/test/test-files/test_with_leading_tag.epp
+++ b/test/test-files/test_with_leading_tag.epp
@@ -1,0 +1,2 @@
+<% if { %>
+content


### PR DESCRIPTION
vim-puppet is currently loading syntax/sh.vim and adding specific puppet region for highlighting.

I tried to detect more finely the original type by asking vim to do a filetypedetect on a filename without '_epp_' extension.
I also changed the _&filetype_ value to _originalfiletype.epuppet_ so various plugins like [ALE](https://github.com/dense-analysis/ale) or [coc.nvim](https://github.com/neoclide/coc.nvim) recognise the original filetype and allow linting or autocompletion
I tried _yaml_, _toml_, various conf file and didn't find any drawback.