### PR TITLE
Try reactivating neovim tests in CI

### DIFF
--- a/.github/workflows/vader.yml
+++ b/.github/workflows/vader.yml
@@ -30,9 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        #neovim: [false, true]
-        # When running vader tests in neovim under github's CI, it coredumps
-        neovim: [false]
+        neovim: [false, true]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
It has been a while since I've had to deactivate neovim in CI because of coredumps. There were new neovim releases since then and maybe changes in github CI.

Let's try to reactivate the tests.