### PR TITLE
fix: in some cases the syntax file can be evaluated before ftplugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ Provides
 * Formatting based on the latest Puppetlabs Style Guide
 * Syntax highlighting compatible with puppet 4.x
   * by default, highlights errors: mixing spaces and tabs and bad names. If you
-    don't want this highlighting, add `let g:puppet_display_errors = v:false`
-    (or really any value that's not `v:true`) to your vimrc.
+    don't want this highlighting, add `let g:puppet_display_errors = 0` to your
+    vimrc.
 * Automatic => alignment
   * If you don't like that, add `let g:puppet_align_hashes = 0` to your vimrc.
 * Ctags support

--- a/ftplugin/puppet.vim
+++ b/ftplugin/puppet.vim
@@ -22,10 +22,6 @@ setlocal commentstring=#\ %s
 
 setlocal formatexpr=puppet#format#Format()
 
-if !exists('g:puppet_display_errors')
-  let g:puppet_display_errors = v:true
-endif
-
 let b:undo_ftplugin = '
     \ setlocal tabstop< tabstop< softtabstop< shiftwidth< expandtab<
     \| setlocal keywordprg< iskeyword< comments< commentstring<

--- a/syntax/puppet.vim
+++ b/syntax/puppet.vim
@@ -14,6 +14,10 @@ endif
 let s:cpo_sav = &cpo
 set cpo&vim
 
+if !exists('g:puppet_display_errors')
+  let g:puppet_display_errors = 1
+endif
+
 syn cluster puppetNotTop contains=@puppetExtendedStringSpecial,@puppetRegexpSpecial,puppetTodo
 
 syn match puppetSpaceError display excludenl "\s\+$"
@@ -282,7 +286,7 @@ hi def link puppetFunction        Function
 hi def link puppetDeprecated      Ignore
 hi def link puppetDebug           Debug
 
-if g:puppet_display_errors ==# v:true
+if g:puppet_display_errors
   hi def link puppetInvalidNumber   Error
   hi def link puppetNameBad         Error
   hi def link puppetSpaceError      Error


### PR DESCRIPTION
Two users, @shadowwa and @dmaes reported errors where vim 9.1 was not happy about the variable g:puppet_display_errors not being defined when evaluating `syntax/puppet.vim`. They found out that the order the plugin scripts were loaded did not reflect my current understanding of how vim loads plugin files: the syntax file was loaded before the ftplugin script, so the variable was indeed not yet defined.

Since the variable is only used in the syntax script, we can declare its default value there if the variable doesn't exist (instead of in the ftplugin file)

I've also changed to using the more common values 0/1 for binary flags in order to use vimscript's "truthy/falsy" nature of a variable.

(Closes: #151)