### PR TITLE
GitHub workflow multiple vim version

### DIFF
--- a/.github/workflows/vader.yml
+++ b/.github/workflows/vader.yml
@@ -33,17 +33,37 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        editor: ["vim", "nvim"]
+        # bullseye:         vim 8.2.2434    neovim 0.4.4
+        # bookworm:         vim 9.0.1378    neovim 0.7.2
+        # trixie:           vim 9.1.0496    neovim 0.9.5
+        # jammy:            vim 8.2.3995    neovim 0.6.1 <- vim version currently used by github action as vim-stable
+        # mantic:           vim 9.0.1672    neovim 0.7.2
+        # noble:            vim 9.1.0016    neovim 0.9.5
+        # mageia 9:         vim 9.1.071     neovim 0.9.5
+        # mageia cauldron:  vim 9.1.0719    neovim 0.10.1
+        # epuppet detestion added in filetype.vim in vim 8.2.2402
+        # neovim pulled this epuppet detection in nvim 0.5.0
+        # filetype detection done with filetype.lua from neovim 0.8.0
+        # neovim < 0.9.0 segfaut on github action (even the one installed from apt)
+        editor: ["vim-v8.0.0000", "vim-stable", "vim-v9.1.0719", "nvim-v0.9.0", "nvim-v0.9.5", "nvim-v0.10.1"]
 
     steps:
       - uses: actions/checkout@v4
+      - name: get editor name
+        env:
+          EDITORVERSION: ${{matrix.editor}}
+        id: split
+        run: |
+          echo "SELECTEDEDITOR=${EDITORVERSION%%-*}" >> $GITHUB_ENV
+          echo "SELECTEDVERSION=${EDITORVERSION##*-}" >> $GITHUB_ENV
       - name: Setup ${{ matrix.editor }}
         uses: rhysd/action-setup-vim@v1
         id: vim
         with:
-          neovim: ${{ matrix.editor == 'nvim' }}
+          neovim: ${{ env.SELECTEDEDITOR == 'nvim' }}
+          version: ${{ env.SELECTEDVERSION }}
       - name: Run Vader unit tests
         run: |
-          TESTVIM=${{ matrix.editor }}
+          TESTVIM=${{ env.SELECTEDEDITOR }}
           export TESTVIM
           ./test/run-tests.sh

--- a/.github/workflows/vader.yml
+++ b/.github/workflows/vader.yml
@@ -13,11 +13,13 @@ jobs:
     name: Lint code with Vint and shellcheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       # There exists a vint github action but it can't install the alpha
       # version. vint has not been moving since 2020 and we need to use the
       # alpha release since it fixed some things wrt the latest stable release.
-      - uses: actions/setup-python@v1
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
       - name: Install vint
         run: pip install --pre vim-vint
       - name: Lint vimscript files
@@ -34,7 +36,7 @@ jobs:
         editor: ["vim", "nvim"]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup ${{ matrix.editor }}
         uses: rhysd/action-setup-vim@v1
         id: vim


### PR DESCRIPTION
- update github action to prevent warning on action run. Had to define python version to prevent another warning, I used 3.10 as it's the version of ubuntu 22.04LTS currently used by github.
- allow to have several versions of vim or nvim tested (unfortunatly, neovim below 0.9.0 segfault, even when trying to install the apt version available)