### PR TITLE
Create tests for bugs reported about empty lines in strings vs indentation (#159)

### DIFF
--- a/test/indent/comments_strings.vader
+++ b/test/indent/comments_strings.vader
@@ -63,3 +63,99 @@ Do (New line):
 Expect puppet (indent stays the same):
   $baz = '[#'
   $qux
+
+-------------------------------------------------------------------------------
+Given puppet (empty line in heredoc):
+  class blah {
+    $value = @(HERE)
+      empty line in here
+  
+      should not affect indentation after here
+      | HERE
+  
+    file { '/tmp/somefile':
+      ensure => 'present',
+    }
+  }
+
+Do (full text indent with '='):
+  gg=G
+
+Expect puppet (indentation shouldn't move):
+  class blah {
+    $value = @(HERE)
+      empty line in here
+  
+      should not affect indentation after here
+      | HERE
+  
+    file { '/tmp/somefile':
+      ensure => 'present',
+    }
+  }
+
+-------------------------------------------------------------------------------
+Given puppet (empty line in string):
+  class blah {
+    $value = 'empty line in here
+  
+      should not affect indentation after here'
+  
+    file { '/tmp/somefile':
+      ensure => 'present',
+    }
+  }
+
+Do (full text indent with '='):
+  gg=G
+
+Expect puppet (indentation shouldn't move):
+  class blah {
+    $value = 'empty line in here
+  
+      should not affect indentation after here'
+  
+    file { '/tmp/somefile':
+      ensure => 'present',
+    }
+  }
+
+-------------------------------------------------------------------------------
+Given puppet (line in string with only spaces):
+  class blah {
+    $value = 'next line contains spaces
+        
+      and should stay the same'
+  }
+
+Do (full text indent with '='):
+  gg=G
+
+Expect puppet (spaces within string should remain there):
+  class blah {
+    $value = 'next line contains spaces
+        
+      and should stay the same'
+  }
+
+-------------------------------------------------------------------------------
+Given puppet (line in heredoc with only spaces):
+  class blah {
+    $value = @(HERE)
+      next line contains spaces
+        
+      and should stay the same
+      | HERE
+  }
+
+Do (full text indent with '='):
+  gg=G
+
+Expect puppet (spaces within string should remain there):
+  class blah {
+    $value = @(HERE)
+      next line contains spaces
+        
+      and should stay the same
+      | HERE
+  }

--- a/test/indent/comments_strings.vader
+++ b/test/indent/comments_strings.vader
@@ -108,6 +108,7 @@ Given puppet (empty line in string):
   }
 
 Do (full text indent with '='):
+  :syntax sync fromstart
   gg=G
 
 Expect puppet (indentation shouldn't move):
@@ -130,6 +131,7 @@ Given puppet (line in string with only spaces):
   }
 
 Do (full text indent with '='):
+  :syntax sync fromstart
   gg=G
 
 Expect puppet (spaces within string should remain there):
@@ -150,6 +152,7 @@ Given puppet (line in heredoc with only spaces):
   }
 
 Do (full text indent with '='):
+  :syntax sync fromstart
   gg=G
 
 Expect puppet (spaces within string should remain there):

--- a/test/indent/comments_strings.vader
+++ b/test/indent/comments_strings.vader
@@ -79,6 +79,7 @@ Given puppet (empty line in heredoc):
   }
 
 Do (full text indent with '='):
+  :syntax sync fromstart
   gg=G
 
 Expect puppet (indentation shouldn't move):


### PR DESCRIPTION
Those are all of the examples that match the reported indentation errors.

The very strange thing is that all of the new tests fail, but they fail differently in vader than how they do in an interactive (n)vim session. The result that we get in those tests is usually that the string contents get wrongly moved to fit indentation. However, when I run the indentation command in the editor, the string contents don't change but things afterwards get indented at the wrong level. I'm not sure why the tests don't behave in the same way.